### PR TITLE
Add standalone popup layer component

### DIFF
--- a/addon/components/popup-layer.js
+++ b/addon/components/popup-layer.js
@@ -115,7 +115,7 @@ export default BaseLayer.extend({
     //...this function, which does nothing but call your action.
     this._layer.onRemove = () => {
       if (this.get('closePopup')) {
-        this.invokeAction('closePopup');
+        Ember.run(() => this.invokeAction('closePopup'));
       }
     };
   },

--- a/addon/components/popup-layer.js
+++ b/addon/components/popup-layer.js
@@ -115,7 +115,7 @@ export default BaseLayer.extend({
     //...this function, which does nothing but call your action.
     this._layer.onRemove = () => {
       if (this.get('closePopup')) {
-        this.get('closePopup')();
+        this.invokeAction('closePopup');
       }
     };
   },

--- a/addon/components/popup-layer.js
+++ b/addon/components/popup-layer.js
@@ -1,0 +1,134 @@
+import Ember from 'ember';
+import layout from '../templates/popup';
+import toLatLng from 'ember-leaflet/macros/to-lat-lng';
+import BaseLayer from 'ember-leaflet/components/base-layer';
+/* global L */
+
+/**
+ * Layer to display a popup in ember-leaflet. Takes popup contents as a
+ * rendering block in the template.
+ *
+ * Available attributes are specified below in `leafletOptions`; these will be
+ * passed along to the L.popup() function in a hash and are equivalent to the
+ * options with the same names in the Leaflet docs.
+ *
+ * Other attributes:
+ *
+ *   - location: an `L.LatLng` or equivalent. Is live-bound to the popup's
+ *     location using `setLatLng`.
+ *   - closePopup: Action, no arguments. Called when the popup should be closed.
+ *     It should usually be used to change a property that controls the display
+ *     of the popup in the template.
+ */
+export default BaseLayer.extend({
+
+  // we need a "tagfull" here to have `this.element`
+  tagName: 'div',
+
+  layout,
+
+  //if this layer is being displayed, popupOpen is ALWAYS true
+  popupOpen: true,
+
+  leafletOptions: [
+    'maxWidth',
+    'minWidth',
+    'maxHeight',
+    'autoPan',
+    'keepInView',
+    'closeButton',
+    'offset',
+    'autoPanPaddingTopLeft',
+    'autoPanPaddingBottomRight',
+    'autoPanPadding',
+    'zoomAnimation',
+    'closeOnClick',
+    'className',
+  ],
+
+  leafletProperties: [
+    'location:setLatLng'
+  ],
+  location: toLatLng(),
+
+  closePopup: null,
+
+  /*
+   * Evil hack by @rwjblue.
+   * `hasBlock` isn't available in js land.
+   * More info: https://github.com/miguelcobain/rfcs/blob/js-has-block/text/0000-js-has-block.md#alternatives
+   */
+  setHasBlock: Ember.computed(function() {
+    this.set('hasBlock', true);
+  }),
+
+  // creates a document fragment that will hold the DOM
+  destinationElement: Ember.computed(function() {
+    return document.createElement('div');
+  }),
+
+  willInsertElement() {
+    this._super(...arguments);
+    this._firstNode = this.element.firstChild;
+    this._lastNode = this.element.lastChild;
+    this.appendToDestination();
+  },
+
+  appendToDestination() {
+    let destinationElement = this.get('destinationElement');
+    this.appendRange(destinationElement, this._firstNode, this._lastNode);
+  },
+
+  appendRange(destinationElement, firstNode, lastNode) {
+    while(firstNode) {
+      destinationElement.insertBefore(firstNode, null);
+      firstNode = firstNode !== lastNode ? lastNode.parentNode.firstChild : null;
+    }
+  },
+
+  createLayer() {
+    const layer = L.popup(this.get('options'));
+    layer.setContent(this.get('destinationElement'));
+    layer.setLatLng(this.get('location'));
+
+    return layer;
+  },
+
+  didCreateLayer() {
+    this._super(...arguments);
+    if (this.get('hasBlock')) {
+      this._hijackPopup();
+    }
+  },
+
+  /**
+   * Traps Leaflet's close event (triggered by the popup close button and, if
+   * `closeOnClick` === `true`, background clicks). Instead of closing the
+   * popup, it will cause the `closePopup` action to be called, allowing you to
+   * tear down the popup in your parent as per data-down, actions-up.
+   */
+  _hijackPopup() {
+    //this function actually causes the popup to be destroyed. we'll save it for
+    //later, and replace it with...
+    this._leafletOnRemove = this._layer.onRemove;
+
+    //...this function, which does nothing but call your action.
+    this._layer.onRemove = () => {
+      if (this.get('closePopup')) {
+        this.get('closePopup')();
+      }
+    };
+  },
+
+  willDestroyLayer() {
+    this._super(...arguments);
+    if (this.get('hasBlock')) {
+      //as noted above, calling this function *actually* removes the popup
+      this._leafletOnRemove.call(this._layer, this._layer._map);
+
+      delete this._firstNode;
+      delete this._lastNode;
+    }
+  }
+
+});

--- a/app/components/popup-layer.js
+++ b/app/components/popup-layer.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-leaflet/components/popup-layer';

--- a/tests/dummy/app/controllers/docs/actions.js
+++ b/tests/dummy/app/controllers/docs/actions.js
@@ -4,11 +4,20 @@ export default Ember.Controller.extend({
   lat: 45.519743,
   lng: -122.680522,
   zoom: 10,
+  popupLocation: null,
   actions: {
     updateCenter(e) {
       let center = e.target.getCenter();
       this.set('lat', center.lat);
       this.set('lng', center.lng);
+    },
+
+    setPopupLocation(e) {
+      this.set('popupLocation', e.latlng);
+    },
+
+    resetPopupLocation() {
+      this.set('popupLocation', null);
     }
   }
 });

--- a/tests/dummy/app/templates/docs/actions.hbs
+++ b/tests/dummy/app/templates/docs/actions.hbs
@@ -48,6 +48,63 @@ export default Ember.Controller.extend({
   do whatever we need when the user interacts with the map.
 </p>
 
+<p>Here's another demo, this one showcasing an independent popup using
+<code>popup-layer</code>. Try clicking anywhere on the map below.</p>
+
+{{#code-sample as |component|}}
+  {{#code-block language="handlebars" class=(concat "code-sample-snippet " (if (eq component.activeTab "template") "active"))}}
+\{{#leaflet-map lat=lat lng=lng zoom=zoom}}
+  \{{tile-layer url="http://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png"}}
+  \{{#if popupLocation}}
+    \{{#popup-layer location=popupLocation closePopup=(action 'resetPopupLocation') closeOnClick=false}}
+      &lt;p&gt;This popup can move! It's currently located at:&lt;/p&gt;
+      &lt;ul&gt;
+        &lt;li&gt;Lat: \{{popupLocation.lat}}&lt;/li&gt;
+        &lt;li&gt;Lng: \{{popupLocation.lng}}&lt;/li&gt;
+      &lt;/ul&gt;
+    \{{/popup-layer}}
+  \{{/if}}
+\{{/leaflet-map}}{{/code-block}}
+  {{#code-block language="javascript" class=(concat "code-sample-snippet " (if (eq component.activeTab "javascript") "active"))}}
+export default Ember.Controller.extend({
+  lat: 45.519743,
+  lng: -122.680522,
+  zoom: 10,
+  popupLocation: [45.519743, -122.680522],
+
+  actions: {
+    setPopupLocation(e) {
+      this.set('popupLocation', e.latlng);
+    },
+
+    resetPopupLocation() {
+      this.set('popupLocation', null);
+    }
+  }
+});{{/code-block}}
+  <div class="code-sample-snippet result {{if (eq component.activeTab "result") "active"}}">
+    {{#leaflet-map lat=lat lng=lng zoom=zoom onClick=(action 'setPopupLocation')}}
+      {{tile-layer url="http://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png"}}
+      {{#if popupLocation}}
+        {{#popup-layer location=popupLocation closePopup=(action 'resetPopupLocation') closeOnClick=false}}
+          <p>This popup can move! It's currently located at:</p>
+          <ul>
+            <li>Lat: {{popupLocation.lat}}</li>
+            <li>Lng: {{popupLocation.lng}}).</li>
+          </ul>
+        {{/popup-layer}}
+      {{/if}}
+    {{/leaflet-map}}
+  </div>
+{{/code-sample}}
+
+<p>Note the binding of <code>resetPopupLocation</code> to <code>closePopup</code>.
+By default, <code>popup-layer</code> triggers the <code>closePopup</code>
+action when you click on the close button, or on the map background (the latter
+has been disabled in this example, using <code>closeOnClick=false</code>). This
+means that a <code>popup-layer</code> won't close unless you handle its
+action.</p>
+
 <p>
   Currently, <strong>all actions get the leaflet raw event passed in</strong>.
 </p>

--- a/tests/integration/components/popup-layer-test.js
+++ b/tests/integration/components/popup-layer-test.js
@@ -37,6 +37,7 @@ test('it fires the close event', function(assert) {
   //that:
 
   let closeButtonDOMElement = this.$('.leaflet-popup-close-button')[0];
+
   closeButtonDOMElement.click();
   assert.equal(this.$('.leaflet-popup').length, 0);
   assert.equal(this.get('popupOpen'), false);

--- a/tests/integration/components/popup-layer-test.js
+++ b/tests/integration/components/popup-layer-test.js
@@ -1,0 +1,52 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+import locations from '../../helpers/locations';
+
+moduleForComponent('popup-layer', 'Integration | Component | popup layer', {
+  integration: true,
+  beforeEach() {
+    this.set('center', locations.nyc);
+    this.set('zoom', 13);
+
+    this.set('popupLocation', locations.nyc);
+    this.set('popupOpen', true);
+  }
+});
+
+test('it fires the close event', function(assert) {
+
+  this.render(hbs`
+    {{#leaflet-map zoom=zoom center=center}}
+      {{#if popupOpen}}
+        {{#popup-layer
+            location=popupLocation
+            closePopup=(action (mut popupOpen) false)}}
+          Popup text!
+        {{/popup-layer}}
+      {{/if}}
+    {{/leaflet-map}}
+  `);
+
+  assert.equal(this.$('.leaflet-popup-content-wrapper').text().trim(), 'Popup text!');
+
+
+  //test that the close button fires the action
+
+  //note that Leaflet's close button only responds to real DOM events, so we
+  //have to pick the actual DOM element out of the query and call click() on
+  //that:
+
+  let closeButtonDOMElement = this.$('.leaflet-popup-close-button')[0];
+  closeButtonDOMElement.click();
+  assert.equal(this.$('.leaflet-popup').length, 0);
+  assert.equal(this.get('popupOpen'), false);
+
+  this.set('popupOpen', true);
+  assert.equal(this.$('.leaflet-popup-content-wrapper').text().trim(), 'Popup text!');
+
+  // test that a background click also fires the action
+  this.$('.leaflet-map-pane').click();
+  assert.equal(this.$('.leaflet-popup').length, 0);
+  assert.equal(this.get('popupOpen'), false);
+
+});


### PR DESCRIPTION
Like #27, this PR includes a `popup-layer`, based on the current popup mixin, which can be used without a marker or path to attach it to.

Unlike #27, this PR does _not_ attempt to rewrite the mixin to use the new layer (since that made for a hugely awkward division of responsibilities between ember-leaflet and Leaflet itself). Instead, the original popup mixin continues to delegate responsibility for positioning/opening/closing of popups to Leaflet itself (thereby preserving Leaflet's `bindPopup` behavior) while the new layer provides fine-grained control over standalone popups.

Also unlike #27, this PR's new test is actually passing! Woo, passing tests.
