### PR TITLE
leaflet 'add' action

### DIFF
--- a/addon/components/marker-layer.js
+++ b/addon/components/marker-layer.js
@@ -16,7 +16,7 @@ export default BaseLayer.extend(DraggabilityMixin, PopupMixin, {
 
   leafletEvents: [
     'click', 'dblclick', 'mousedown', 'mouseover', 'mouseout',
-    'contextmenu', 'dragstart', 'drag', 'dragend', 'move', 'remove',
+    'contextmenu', 'dragstart', 'drag', 'dragend', 'move', 'remove', 'add',
     'popupopen', 'popupclose'
   ],
 


### PR DESCRIPTION
can 'add' be implemented in leafletEvents so that 'onAdd' can be called on the {{marker-layer}} interface?  
I've tested this locally, but am unsure if it has any other consequences,

thanks!
Peter