### PR TITLE
Implemented GeoJSONLayer

### DIFF
--- a/addon/components/geojson-layer.js
+++ b/addon/components/geojson-layer.js
@@ -1,7 +1,6 @@
 import Ember from 'ember';
 import BaseLayer from 'ember-leaflet/components/base-layer';
 import PathLayer from 'ember-leaflet/components/path-layer';
-import PopupMixin from 'ember-leaflet/mixins/popup';
 /* global L */
 
 /**
@@ -12,7 +11,7 @@ import PopupMixin from 'ember-leaflet/mixins/popup';
  *   - geoJSON: the GeoJSON object to render
  *   - all standard leaflet options for L.geoJson
  */
-export default BaseLayer.extend(PopupMixin, {
+export default BaseLayer.extend({
   leafletOptions: [
     'stroke', 'color', 'weight', 'opacity', 'fill', 'fillColor',
     'fillOpacity', 'fillRule', 'dashArray', 'lineCap', 'lineJoin',

--- a/addon/components/geojson-layer.js
+++ b/addon/components/geojson-layer.js
@@ -29,7 +29,7 @@ export default BaseLayer.extend({
   geoJSON: null,
   _lastPushedToLeaflet: null,
 
-  didReceiveAttrs() {
+  didUpdateAttrs() {
     const currentGeoJSON = this.get('geoJSON');
     if (currentGeoJSON !== this.get('_lastPushedToLeaflet')) {
       this.pushDataToLeaflet(currentGeoJSON);

--- a/addon/components/geojson-layer.js
+++ b/addon/components/geojson-layer.js
@@ -25,19 +25,33 @@ export default BaseLayer.extend({
   ],
 
   geoJSON: null,
-  pushDataToLeaflet: Ember.observer('geoJSON', function() {
-    const geoJSON = this.get('geoJSON');
-    if (!this._layer || !geoJSON) {
+  _lastPushedToLeaflet: null,
+
+  didReceiveAttrs() {
+    const currentGeoJSON = this.get('geoJSON');
+    if (currentGeoJSON !== this.get('_lastPushedToLeaflet')) {
+      this.pushDataToLeaflet(currentGeoJSON);
+    }
+  },
+
+  pushDataToLeaflet(geoJSON) {
+    if (!this._layer) {
       return;
     }
+
+    this.set('_lastPushedToLeaflet', geoJSON);
 
     //recall that GeoJSON layers are actually layer groups -- we have to clear
     //their contents first...
     this._layer.clearLayers();
 
+    if (!geoJSON) {
+      //(can't add new data if we don't have anything to add)
+      return;
+    }
     //...then add new data to recreate the child layers in an updated form
-    this._layer.addData(this.get('geoJSON'));
-  }),
+    this._layer.addData(geoJSON);
+  },
 
   createLayer() {
     return L.geoJson(null, this.get('options'));
@@ -45,6 +59,6 @@ export default BaseLayer.extend({
 
   didCreateLayer() {
     this._super(...arguments);
-    this.pushDataToLeaflet();
+    this.pushDataToLeaflet(this.get('geoJSON'));
   }
 });

--- a/addon/components/geojson-layer.js
+++ b/addon/components/geojson-layer.js
@@ -1,0 +1,51 @@
+import Ember from 'ember';
+import BaseLayer from 'ember-leaflet/components/base-layer';
+import PathLayer from 'ember-leaflet/components/path-layer';
+import PopupMixin from 'ember-leaflet/mixins/popup';
+/* global L */
+
+/**
+ * An ember-leaflet wrapper for L.geoJson, which renders GeoJson data onto a
+ * map as features.
+ *
+ * Takes:
+ *   - geoJSON: the GeoJSON object to render
+ *   - all standard leaflet options for L.geoJson
+ */
+export default BaseLayer.extend(PopupMixin, {
+  leafletOptions: [
+    'stroke', 'color', 'weight', 'opacity', 'fill', 'fillColor',
+    'fillOpacity', 'fillRule', 'dashArray', 'lineCap', 'lineJoin',
+    'clickable', 'pointerEvents', 'className', 'pointToLayer',
+    'style', 'onEachFeature', 'filter', 'coordsToLatLng'
+  ],
+
+  leafletEvents: [
+    'click', 'dblclick', 'mousedown', 'mouseover', 'mouseout',
+    'contextmenu', 'add', 'remove', 'popupopen', 'popupclose'
+  ],
+
+  geoJSON: null,
+  pushDataToLeaflet: Ember.observer('geoJSON', function() {
+    const geoJSON = this.get('geoJSON');
+    if (!this._layer || !geoJSON) {
+      return;
+    }
+
+    //recall that GeoJSON layers are actually layer groups -- we have to clear
+    //their contents first...
+    this._layer.clearLayers();
+
+    //...then add new data to recreate the child layers in an updated form
+    this._layer.addData(this.get('geoJSON'));
+  }),
+
+  createLayer() {
+    return L.geoJson(null, this.get('options'));
+  },
+
+  didCreateLayer() {
+    this._super(...arguments);
+    this.pushDataToLeaflet();
+  }
+});

--- a/addon/components/geojson-layer.js
+++ b/addon/components/geojson-layer.js
@@ -12,6 +12,8 @@ import PathLayer from 'ember-leaflet/components/path-layer';
  *   - all standard leaflet options for L.geoJson
  */
 export default BaseLayer.extend({
+  leafletRequiredOptions: ['geoJSON'],
+
   leafletOptions: [
     'stroke', 'color', 'weight', 'opacity', 'fill', 'fillColor',
     'fillOpacity', 'fillRule', 'dashArray', 'lineCap', 'lineJoin',
@@ -54,11 +56,6 @@ export default BaseLayer.extend({
   },
 
   createLayer() {
-    return L.geoJson(null, this.get('options'));
-  },
-
-  didCreateLayer() {
-    this._super(...arguments);
-    this.pushDataToLeaflet(this.get('geoJSON'));
+    return L.geoJson(...this.get('requiredOptions'), this.get('options'));
   }
 });

--- a/addon/components/geojson-layer.js
+++ b/addon/components/geojson-layer.js
@@ -26,13 +26,9 @@ export default BaseLayer.extend({
     'contextmenu', 'add', 'remove', 'popupopen', 'popupclose'
   ],
 
-  geoJSON: null,
-  _lastPushedToLeaflet: null,
-
-  didUpdateAttrs() {
-    const currentGeoJSON = this.get('geoJSON');
-    if (currentGeoJSON !== this.get('_lastPushedToLeaflet')) {
-      this.pushDataToLeaflet(currentGeoJSON);
+  didUpdateAttrs({ newAttrs }) {
+    if (newAttrs.geoJSON) {
+      this.pushDataToLeaflet(newAttrs.geoJSON.value);
     }
   },
 
@@ -41,18 +37,14 @@ export default BaseLayer.extend({
       return;
     }
 
-    this.set('_lastPushedToLeaflet', geoJSON);
-
     //recall that GeoJSON layers are actually layer groups -- we have to clear
     //their contents first...
     this._layer.clearLayers();
 
-    if (!geoJSON) {
-      //(can't add new data if we don't have anything to add)
-      return;
+    if (geoJSON) {
+      //...then add new data to recreate the child layers in an updated form
+      this._layer.addData(geoJSON);
     }
-    //...then add new data to recreate the child layers in an updated form
-    this._layer.addData(geoJSON);
   },
 
   createLayer() {

--- a/addon/templates/current/leaflet-map.hbs
+++ b/addon/templates/current/leaflet-map.hbs
@@ -6,4 +6,5 @@
     image=(component "image-layer" containerLayer=this)
     polyline=(component "polyline-layer" containerLayer=this)
     polygon=(component "polygon-layer" containerLayer=this)
+    geoJSON=(component "geojson-layer" containerLayer=this)
   )}}

--- a/app/components/geojson-layer.js
+++ b/app/components/geojson-layer.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-leaflet/components/geojson-layer';

--- a/tests/dummy/app/templates/docs/contextual-components.hbs
+++ b/tests/dummy/app/templates/docs/contextual-components.hbs
@@ -16,6 +16,7 @@
     <li><code>\{{layers.image</code> equivalent to <code>\{{image-layer</code></li>
     <li><code>\{{layers.polyline</code> equivalent to <code>\{{polyline-layer</code></li>
     <li><code>\{{layers.polygon</code> equivalent to <code>\{{polygon-layer</code></li>
+    <li><code>\{{layers.geoJSON</code> equivalent to <code>\{{geojson-layer</code></li>
   </ul>
 
    If you're using an Ember version later or equal to <code>2.3.0-beta.1</code>, you should use this feature.

--- a/tests/helpers/sample-geojson.js
+++ b/tests/helpers/sample-geojson.js
@@ -1,0 +1,35 @@
+import locations from './locations';
+
+const chicago = locations.chicago;
+
+export default {
+  type: 'FeatureCollection',
+  features: [
+    {
+      type: 'Feature',
+      geometry: {
+        type: 'Point',
+        coordinates: [chicago.lng, chicago.lat]
+      },
+      properties: {
+        name: 'Chicago'
+      }
+    },
+
+    {
+      type: 'Feature',
+      geometry: {
+        type: 'Polygon',
+        coordinates: [[
+          [chicago.lng - 0.01, chicago.lat - 0.01],
+          [chicago.lng + 0.01, chicago.lat - 0.01],
+          [chicago.lng + 0.01, chicago.lat + 0.01],
+          [chicago.lng - 0.01, chicago.lat + 0.01],
+        ]]
+      },
+      properties: {
+        name: 'A Rectangle'
+      }
+    }
+  ]
+};

--- a/tests/integration/components/geojson-layer-test.js
+++ b/tests/integration/components/geojson-layer-test.js
@@ -6,10 +6,6 @@ import locations from '../../helpers/locations';
 import sampleGeoJSON from '../../helpers/sample-geojson';
 /* globals L */
 
-//Needed to silence leaflet autodetection error
-L.Icon.Default.imagePath = 'some-path';
-
-
 const emptyGeoJSON = {
   type: 'FeatureCollection',
   features: []
@@ -73,8 +69,8 @@ test('re-render SVG and markers after geoJSON changes', function(assert) {
 
   //...now let's force a re-render, clearing all the geoJSON from the map
 
-  //NOTE that it's not enough to push new data into the geoJSON hash -- we must
-  //replace it entirely.
+  //NOTE that it's not enough to modify the geoJSON hash -- we must replace it
+  //entirely.
   this.set('sampleGeoJSON', emptyGeoJSON);
 
   const polygonPath = this.$('path');

--- a/tests/integration/components/geojson-layer-test.js
+++ b/tests/integration/components/geojson-layer-test.js
@@ -1,0 +1,59 @@
+import Ember from 'ember';
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+import { assertionInjector, assertionCleanup } from '../../assertions';
+import GeoJSONLayerComponent from 'ember-leaflet/components/geojson-layer';
+import locations from '../../helpers/locations';
+import sampleGeoJSON from '../../helpers/sample-geojson';
+/* globals L */
+
+//Needed to silence leaflet autodetection error
+L.Icon.Default.imagePath = 'some-path';
+
+let geoJSONLayer;
+
+moduleForComponent('geojson-layer', 'Integration | Component | geojson layer', {
+  integration: true,
+  beforeEach() {
+    assertionInjector();
+
+    this.register('component:geojson-layer', GeoJSONLayerComponent.extend({
+      init() {
+        this._super(...arguments);
+        geoJSONLayer = this;
+      }
+    }));
+
+    this.set('center', locations.chicago);
+    this.set('zoom', 14);
+
+    this.set('sampleGeoJSON', sampleGeoJSON);
+  },
+  afterEach() {
+    assertionCleanup();
+  }
+});
+
+test('render geoJSON as SVG and Markers', function(assert) {
+  this.render(hbs`
+    {{#leaflet-map zoom=zoom center=center}}
+      {{geojson-layer geoJSON=sampleGeoJSON}}
+    {{/leaflet-map}}
+  `);
+
+  //renders polygon as SVG:
+  const polygonPath = this.$('path');
+
+  assert.strictEqual(polygonPath.length, 1);
+
+  //this property should have *something* in it if we've done our job, leave it
+  //to Leaflet to test that the GeoJSONLayer populates it correctly
+  assert.ok(polygonPath.attr('d'));
+
+  //renders point as marker:
+  const markers = geoJSONLayer._layer.getLayers().filter(
+    (layer) => layer instanceof L.Marker);
+
+  assert.strictEqual(markers.length, 1);
+  assert.locationsEqual(markers[0].getLatLng(), locations.chicago);
+});

--- a/tests/integration/components/geojson-layer-test.js
+++ b/tests/integration/components/geojson-layer-test.js
@@ -9,6 +9,12 @@ import sampleGeoJSON from '../../helpers/sample-geojson';
 //Needed to silence leaflet autodetection error
 L.Icon.Default.imagePath = 'some-path';
 
+
+const emptyGeoJSON = {
+  type: 'FeatureCollection',
+  features: []
+};
+
 let geoJSONLayer;
 
 moduleForComponent('geojson-layer', 'Integration | Component | geojson layer', {
@@ -55,4 +61,26 @@ test('render geoJSON as SVG and Markers', function(assert) {
 
   assert.strictEqual(markers.length, 1);
   assert.locationsEqual(markers[0].getLatLng(), locations.chicago);
+});
+
+test('re-render SVG and markers after geoJSON changes', function(assert) {
+  //we know this works, as per the above test...
+  this.render(hbs`
+    {{#leaflet-map zoom=zoom center=center}}
+      {{geojson-layer geoJSON=sampleGeoJSON}}
+    {{/leaflet-map}}
+  `);
+
+  //...now let's force a re-render, clearing all the geoJSON from the map
+
+  //NOTE that it's not enough to push new data into the geoJSON hash -- we must
+  //replace it entirely.
+  this.set('sampleGeoJSON', emptyGeoJSON);
+
+  const polygonPath = this.$('path');
+  assert.strictEqual(polygonPath.length, 0);
+
+  const markers = geoJSONLayer._layer.getLayers().filter(
+    (layer) => layer instanceof L.Marker);
+  assert.strictEqual(markers.length, 0);
 });

--- a/tests/integration/components/geojson-layer-test.js
+++ b/tests/integration/components/geojson-layer-test.js
@@ -1,4 +1,3 @@
-import Ember from 'ember';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import { assertionInjector, assertionCleanup } from '../../assertions';


### PR DESCRIPTION
This PR implements `L.geoJson` as `{{geojson-layer}}` (and the `layers.geoJSON` contextual component). It has an integration test showing that the layer exhibits the default Leaflet behavior for GeoJSON (`Point` geometry as markers, and other stuff as SVG).

In practice, I suspect most users will want to subclass this layer to implement specific drawing logic (for options like `filter`, `style`, and `onEachFeature`, which are all callback functions). This makes it somewhat more complex to use effectively than the other layers, and I think it could use some documentation beyond the generated API docs. I'm happy to write that and add it to the PR, I just don't know where in the docs it should go.