### PR TITLE
#59 Extends observers to support bounds:fitBounds:fitBoundsOptions

### DIFF
--- a/addon/components/base-layer.js
+++ b/addon/components/base-layer.js
@@ -120,12 +120,7 @@ export default Component.extend(ChildMixin, InvokeActionMixin, {
       this._observers[property] = function() {
         let value = this.get(objectProperty);
         assert(this.constructor + ' must have a ' + leafletProperty + ' function.', !!this._layer[leafletProperty]);
-        let propertyParams = [];
-        if (params) {
-          params.forEach(paramProperty => {
-            propertyParams.push(this.get(paramProperty));
-          });
-        }
+        let propertyParams = params.map(p => this.get(p));
         this._layer[leafletProperty].call(this._layer, value, ...propertyParams);
       };
 

--- a/addon/components/base-layer.js
+++ b/addon/components/base-layer.js
@@ -113,14 +113,20 @@ export default Component.extend(ChildMixin, InvokeActionMixin, {
     this._observers = {};
     this.get('leafletProperties').forEach(propExp => {
 
-      let [property, leafletProperty] = propExp.split(':');
+      let [property, leafletProperty, ...params] = propExp.split(':');
       if (!leafletProperty) { leafletProperty = 'set' + Ember.String.classify(property); }
       let objectProperty = property.replace(/\.\[]/, ''); //allow usage of .[] to observe array changes
 
       this._observers[property] = function() {
         let value = this.get(objectProperty);
         assert(this.constructor + ' must have a ' + leafletProperty + ' function.', !!this._layer[leafletProperty]);
-        this._layer[leafletProperty].call(this._layer, value);
+        let propertyParams = [];
+        if (params) {
+          params.forEach(paramProperty => {
+            propertyParams.push(this.get(paramProperty));
+          });
+        }
+        this._layer[leafletProperty].call(this._layer, value, ...propertyParams);
       };
 
       this.addObserver(property, this, this._observers[property]);

--- a/addon/components/leaflet-map.js
+++ b/addon/components/leaflet-map.js
@@ -4,6 +4,7 @@ import ContainerMixin from 'ember-leaflet/mixins/container';
 import toLatLng from 'ember-leaflet/macros/to-lat-lng';
 import layout from '../templates/leaflet-map';
 const { assert } = Ember;
+const assign = Ember.assign || Ember.merge;
 
 export default BaseLayer.extend(ContainerMixin, {
   tagName: 'div',
@@ -38,7 +39,7 @@ export default BaseLayer.extend(ContainerMixin, {
   ],
 
   leafletProperties: [
-    'zoom:setZoom', 'center:panTo:panOptions', 'maxBounds:setMaxBounds', 'bounds:fitBounds:fitBoundsOptions'
+    'zoom:setZoom', 'center:panTo:zoomPanOptions', 'maxBounds:setMaxBounds', 'bounds:fitBounds:fitBoundsOptions'
   ],
 
   center: toLatLng(),
@@ -85,10 +86,10 @@ export default BaseLayer.extend(ContainerMixin, {
       (!this.get('bounds') && (this.get('center') && this.get('zoom') !== undefined))
     );
     if (this.get('bounds')) {
-      this._layer.fitBounds(this.get('bounds'), Ember.assign({reset: true}, this.get('fitBoundsOptions')));
+      this._layer.fitBounds(this.get('bounds'), assign({reset: true}, this.get('fitBoundsOptions')));
     } else {
 
-      this._layer.setView(this.get('center'), this.get('zoom'), {reset: true});
+      this._layer.setView(this.get('center'), this.get('zoom'), assign({reset: true}, this.get('zoomPanOptions')));
     }
   }
 });

--- a/addon/components/leaflet-map.js
+++ b/addon/components/leaflet-map.js
@@ -38,7 +38,7 @@ export default BaseLayer.extend(ContainerMixin, {
   ],
 
   leafletProperties: [
-    'zoom:setZoom', 'center:panTo', 'maxBounds:setMaxBounds', 'bounds:fitBounds:fitBoundsOptions'
+    'zoom:setZoom', 'center:panTo:panOptions', 'maxBounds:setMaxBounds', 'bounds:fitBounds:fitBoundsOptions'
   ],
 
   center: toLatLng(),
@@ -85,7 +85,7 @@ export default BaseLayer.extend(ContainerMixin, {
       (!this.get('bounds') && (this.get('center') && this.get('zoom') !== undefined))
     );
     if (this.get('bounds')) {
-      this._layer.fitBounds(this.get('bounds'), this.get('fitBoundsOptions'));
+      this._layer.fitBounds(this.get('bounds'), Ember.assign({reset: true}, this.get('fitBoundsOptions')));
     } else {
 
       this._layer.setView(this.get('center'), this.get('zoom'), {reset: true});

--- a/addon/components/leaflet-map.js
+++ b/addon/components/leaflet-map.js
@@ -38,7 +38,7 @@ export default BaseLayer.extend(ContainerMixin, {
   ],
 
   leafletProperties: [
-    'zoom:setZoom', 'center:panTo', 'maxBounds:setMaxBounds', 'bounds:fitBounds'
+    'zoom:setZoom', 'center:panTo', 'maxBounds:setMaxBounds', 'bounds:fitBounds:fitBoundsOptions'
   ],
 
   center: toLatLng(),
@@ -85,7 +85,7 @@ export default BaseLayer.extend(ContainerMixin, {
       (!this.get('bounds') && (this.get('center') && this.get('zoom') !== undefined))
     );
     if (this.get('bounds')) {
-      this._layer.fitBounds(this.get('bounds'), {reset: true});
+      this._layer.fitBounds(this.get('bounds'), this.get('fitBoundsOptions'));
     } else {
 
       this._layer.setView(this.get('center'), this.get('zoom'), {reset: true});

--- a/tests/integration/components/leaflet-map-test.js
+++ b/tests/integration/components/leaflet-map-test.js
@@ -85,12 +85,13 @@ test('update map layer using leafletProperties (bounds and then center)', functi
 });
 
 test('update map layer using leafletProperties (bounds and fitBoundsOptions)', function(assert) {
+  this.set('fitBoundsOptions', null);
   this.set('bounds', [locations.nyc, locations.chicago]);
-  this.render(hbs`{{leaflet-map bounds=bounds}}`);
+  this.render(hbs`{{leaflet-map bounds=bounds fitBoundsOptions=fitBoundsOptions}}`);
   let pixelBounds = map._layer.getPixelBounds();
 
-  this.set('fitBoundsOptions', {padding: L.point(100, 100)});
-  this.render(hbs`{{leaflet-map bounds=bounds fitBoundsOptions=fitBoundsOptions}}`);
+  this.set('fitBoundsOptions', {padding: L.point(500, 500)});
+  this.set('bounds', [locations.chicago, locations.nyc]);
   let pixelBoundsWithOptions = map._layer.getPixelBounds();
 
   assert.notEqual(pixelBounds.min.x, pixelBoundsWithOptions.min.x);

--- a/tests/integration/components/leaflet-map-test.js
+++ b/tests/integration/components/leaflet-map-test.js
@@ -3,7 +3,6 @@ import hbs from 'htmlbars-inline-precompile';
 import { assertionInjector, assertionCleanup } from '../../assertions';
 import LeafletMapComponent from 'ember-leaflet/components/leaflet-map';
 import locations from '../../helpers/locations';
-/* globals L */
 
 let map;
 
@@ -90,7 +89,7 @@ test('update map layer using leafletProperties (bounds and fitBoundsOptions)', f
   this.render(hbs`{{leaflet-map bounds=bounds fitBoundsOptions=fitBoundsOptions}}`);
   let pixelBounds = map._layer.getPixelBounds();
 
-  this.set('fitBoundsOptions', {padding: L.point(500, 500)});
+  this.set('fitBoundsOptions', {padding: [500, 500]});
   this.set('bounds', [locations.chicago, locations.nyc]);
   let pixelBoundsWithOptions = map._layer.getPixelBounds();
 

--- a/tests/integration/components/leaflet-map-test.js
+++ b/tests/integration/components/leaflet-map-test.js
@@ -3,6 +3,7 @@ import hbs from 'htmlbars-inline-precompile';
 import { assertionInjector, assertionCleanup } from '../../assertions';
 import LeafletMapComponent from 'ember-leaflet/components/leaflet-map';
 import locations from '../../helpers/locations';
+/* globals L */
 
 let map;
 
@@ -81,6 +82,19 @@ test('update map layer using leafletProperties (bounds and then center)', functi
   this.set('center2', locations.nyc);
 
   assert.locationsEqual(map._layer.getCenter(), locations.nyc);
+});
+
+test('update map layer using leafletProperties (bounds and fitBoundsOptions)', function(assert) {
+  this.set('bounds', [locations.nyc, locations.chicago]);
+  this.render(hbs`{{leaflet-map bounds=bounds}}`);
+  let pixelBounds = map._layer.getPixelBounds();
+
+  this.set('fitBoundsOptions', {padding: L.point(100, 100)});
+  this.render(hbs`{{leaflet-map bounds=bounds fitBoundsOptions=fitBoundsOptions}}`);
+  let pixelBoundsWithOptions = map._layer.getPixelBounds();
+
+  assert.notEqual(pixelBounds.min.x, pixelBoundsWithOptions.min.x);
+  assert.notEqual(pixelBounds.min.y, pixelBoundsWithOptions.min.y);
 });
 
 test('map sends actions for events', function(assert) {


### PR DESCRIPTION
Proof of concept how `bounds:fitBounds:fitBoundsOptions` could work. 

This allows for:

```
{{#leaflet-map
  maxZoom=10
  bounds=bounds
  fitBoundsOptions=(hash
    padding=(point 20 20)
    maxZoom=10
  )
}}
```

Things to do:
- [x] Correctly merge `{reset: true}` with fitBoundsOptions
- [x] Tests