### PR TITLE
Adding popupOptions to marker-layer component

### DIFF
--- a/addon/mixins/popup.js
+++ b/addon/mixins/popup.js
@@ -54,7 +54,7 @@ export default Mixin.create({
   didCreateLayer() {
     this._super(...arguments);
     if (this.get('hasBlock')) {
-      this._popup = this.L.popup({}, this._layer);
+      this._popup = this.L.popup(this.get ('popupOptions'), this._layer);
       this._popup.setContent(this.get('destinationElement'));
       this._layer.bindPopup(this._popup);
 

--- a/tests/integration/components/marker-layer-test.js
+++ b/tests/integration/components/marker-layer-test.js
@@ -183,14 +183,3 @@ test('using icons from div-icon helper works', function(assert) {
   assert.equal(marker._layer.options.icon.options.iconSize.x, 21);
   assert.equal(marker._layer.options.icon.options.iconSize.y, 21);
 });
-
-test('popupOptions hash', function(assert) {
-  this.set('markerCenter', locations.nyc);
-  this.render(hbs`
-    {{#leaflet-map zoom=zoom center=center}}
-      {{marker-layer location=markerCenter draggable=draggable popupOptions=(hash className="foo")}}
-    {{/leaflet-map}}
-  `);
-
-  assert.equal(marker._popup.options.className, 'foo');
-});

--- a/tests/integration/components/marker-layer-test.js
+++ b/tests/integration/components/marker-layer-test.js
@@ -188,7 +188,7 @@ test('popupOptions hash', function(assert) {
   this.set('markerCenter', locations.nyc);
   this.render(hbs`
     {{#leaflet-map zoom=zoom center=center}}
-      {{marker-layer location=markerCenter draggable=draggable (hash className="foo")}}
+      {{marker-layer location=markerCenter draggable=draggable popupOptions=(hash className="foo")}}
     {{/leaflet-map}}
   `);
 

--- a/tests/integration/components/marker-layer-test.js
+++ b/tests/integration/components/marker-layer-test.js
@@ -183,3 +183,14 @@ test('using icons from div-icon helper works', function(assert) {
   assert.equal(marker._layer.options.icon.options.iconSize.x, 21);
   assert.equal(marker._layer.options.icon.options.iconSize.y, 21);
 });
+
+test('popupOptions hash', function(assert) {
+  this.set('markerCenter', locations.nyc);
+  this.render(hbs`
+    {{#leaflet-map zoom=zoom center=center}}
+      {{marker-layer location=markerCenter draggable=draggable (hash className="foo")}}
+    {{/leaflet-map}}
+  `);
+
+  assert.equal(marker._popup.options.className, 'foo');
+});

--- a/tests/integration/components/popup-test.js
+++ b/tests/integration/components/popup-test.js
@@ -142,3 +142,14 @@ test('popup closes when layer is destroyed', function(assert) {
   assert.equal(map._popup, null, 'popup closed');
 
 });
+
+test('popupOptions hash', function(assert) {
+  this.set('markerCenter', locations.nyc);
+  this.render(hbs`
+    {{#leaflet-map zoom=zoom center=center}}
+      {{marker-layer location=markerCenter draggable=draggable popupOptions=(hash className="foo")}}
+    {{/leaflet-map}}
+  `);
+  
+  assert.equal(marker._popup.options.className, 'foo');
+});

--- a/tests/integration/components/popup-test.js
+++ b/tests/integration/components/popup-test.js
@@ -145,9 +145,10 @@ test('popup closes when layer is destroyed', function(assert) {
 
 test('popupOptions hash', function(assert) {
   this.set('markerCenter', locations.nyc);
+  this.set('popupOptions', { className: 'foo' });
   this.render(hbs`
     {{#leaflet-map zoom=zoom center=center}}
-      {{#marker-layer location=markerCenter draggable=draggable popupOptions=(hash className="foo")}}
+      {{#marker-layer location=markerCenter draggable=draggable popupOptions=popupOptions}}
         Popup Content
       {{/marker-layer}}
     {{/leaflet-map}}

--- a/tests/integration/components/popup-test.js
+++ b/tests/integration/components/popup-test.js
@@ -153,5 +153,5 @@ test('popupOptions hash', function(assert) {
     {{/leaflet-map}}
   `);
   
-  assert.equal(marker._popup.options.className, 'foo');
+  assert.equal(marker._popup.options.className, 'foo', 'popup class set');
 });

--- a/tests/integration/components/popup-test.js
+++ b/tests/integration/components/popup-test.js
@@ -147,7 +147,9 @@ test('popupOptions hash', function(assert) {
   this.set('markerCenter', locations.nyc);
   this.render(hbs`
     {{#leaflet-map zoom=zoom center=center}}
-      {{marker-layer location=markerCenter draggable=draggable popupOptions=(hash className="foo")}}
+      {{#marker-layer location=markerCenter draggable=draggable popupOptions=(hash className="foo")}}
+        Popup Content
+      {{/marker-layer}}
     {{/leaflet-map}}
   `);
   


### PR DESCRIPTION
As discussed in #58, now this:

```
{{#marker-layer lat=lat lng=lng
  popupOptions=(hash
    className="foo"
  )}}
  FooBar
{{/marker-layer}}
```

can be used, and popup will get the parameters passed using `popupOptions` hash. Included a test that will check the `className` value in `marker._popup.options.className`.