### PR TITLE
Add test and fix for popupOptions being passed into a circle-layer.

### DIFF
--- a/addon/mixins/popup.js
+++ b/addon/mixins/popup.js
@@ -63,7 +63,7 @@ export default Mixin.create({
   didCreateLayer() {
     this._super(...arguments);
     if (this.get('hasBlock')) {
-      this._popup = this.L.popup({}, this._layer);
+      this._popup = this.L.popup(this.get('popupOptions'), this._layer);
       this._popup.setContent(this.get('destinationElement'));
       this._layer.bindPopup(this._popup, this.get('popupOptions'));
 

--- a/tests/integration/components/circle-layer-test.js
+++ b/tests/integration/components/circle-layer-test.js
@@ -69,3 +69,18 @@ test('lat/lng changes propagate to the circle layer', function(assert) {
 
   assert.locationsEqual(circle._layer.getLatLng(), locations.london);
 });
+
+
+test('popupOptions hash applies to the popup', function(assert) {
+  this.set('circleCenter', locations.nyc);
+  this.set('popupOptions', { className: 'circle' });
+  this.render(hbs`
+    {{#leaflet-map zoom=zoom center=center}}
+      {{#circle-layer location=circleCenter radius=5 popupOptions=popupOptions}}
+        Circle Content
+      {{/circle-layer}}
+    {{/leaflet-map}}
+  `);
+
+  assert.equal(circle._popup.options.className, 'circle', 'options passed to circle-layer correctly');
+});

--- a/tests/integration/components/circle-layer-test.js
+++ b/tests/integration/components/circle-layer-test.js
@@ -69,18 +69,3 @@ test('lat/lng changes propagate to the circle layer', function(assert) {
 
   assert.locationsEqual(circle._layer.getLatLng(), locations.london);
 });
-
-
-test('popupOptions hash applies to the popup', function(assert) {
-  this.set('circleCenter', locations.nyc);
-  this.set('popupOptions', { className: 'circle' });
-  this.render(hbs`
-    {{#leaflet-map zoom=zoom center=center}}
-      {{#circle-layer location=circleCenter radius=5 popupOptions=popupOptions}}
-        Circle Content
-      {{/circle-layer}}
-    {{/leaflet-map}}
-  `);
-
-  assert.equal(circle._popup.options.className, 'circle', 'options passed to circle-layer correctly');
-});

--- a/tests/integration/components/popup-test.js
+++ b/tests/integration/components/popup-test.js
@@ -166,9 +166,9 @@ test('popup closes with yielded action', function(assert) {
   assert.equal(map._popup, null, 'popup closed');
 });
 
-test('popupOptions hash', function(assert) {
+test('popupOptions hash on marker-layer', function(assert) {
   this.set('markerCenter', locations.nyc);
-  this.set('popupOptions', { className: 'foo' });
+  this.set('popupOptions', { className: 'marker' });
   this.render(hbs`
     {{#leaflet-map zoom=zoom center=center}}
       {{#marker-layer location=markerCenter draggable=draggable popupOptions=popupOptions}}
@@ -177,5 +177,5 @@ test('popupOptions hash', function(assert) {
     {{/leaflet-map}}
   `);
 
-  assert.equal(marker._popup.options.className, 'foo', 'popup class set');
+  assert.equal(marker._popup.options.className, 'marker', 'options passed to marker-later correctly');
 });


### PR DESCRIPTION
 Fix should work for all path-layer children.

Fix consists of simply creating the initial `L.Popup` with the passed in `popupOptions`. There's no need to pass them into the `bindPopup` call in Leaflet.