### PR TITLE
add ember-leaflet-tiles-cache to the list of addons

### DIFF
--- a/tests/dummy/app/templates/addons.hbs
+++ b/tests/dummy/app/templates/addons.hbs
@@ -56,6 +56,10 @@
         <a href="https://github.com/knownasilya/ember-leaflet-cartodb">ember-leaflet-cartodb</a> - Provides CartoDB.js layers for ember-leaflet
       </li>
 
+      <li>
+        <a href="https://github.com/pavloo/ember-leaflet-tiles-cache">ember-leaflet-tiles-cache</a> - Extends tile layer to support tile caching
+      </li>
+
     </ul>
   </section>
 </section>


### PR DESCRIPTION
The addon is also tested with `ember-leaflet 2.2.8-beta.1` and works fine