### PR TITLE
Allow execution on fastboot

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,10 @@ Think of your map as a set of layers inside a container. Your main container wil
 * `ember test`
 * `ember test --server`
 
+## Fastboot support
+
+There's rudimentary support for fastboot right now. Node.js 6.0 an up work out of the box. For node.js < 6.0 you have to start the fastboot server with `--harmony_proxies` like `node --harmony_proxies node_modules/.bin/ember fastboot`.
+
 ## Building
 
 * `ember build`

--- a/addon/L.js
+++ b/addon/L.js
@@ -1,0 +1,21 @@
+/* global L */
+
+let L_ = null;
+
+if (typeof L !== 'undefined') {
+  L_ = L;
+} else {
+  let N = () => {};
+
+  L_ = new Proxy({}, {
+    get() {
+      return N;
+    }
+  });
+
+  L_.Icon.Default = {};
+  L_.tileLayer.wms = N;
+}
+
+export default L_;
+

--- a/addon/L.js
+++ b/addon/L.js
@@ -6,13 +6,13 @@ if (typeof L !== 'undefined') {
   L_ = L;
 } else {
   let N = () => {};
-
-  L_ = new Proxy({}, {
+  let handler = {
     get() {
       return N;
     }
-  });
+  };
 
+  L_ = Proxy.create ? Proxy.create(handler) : new Proxy({}, handler);
   L_.Icon.Default = {};
   L_.tileLayer.wms = N;
 }

--- a/addon/components/base-layer.js
+++ b/addon/components/base-layer.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 import { ChildMixin } from 'ember-composability-tools';
 import { InvokeActionMixin } from 'ember-invoke-action';
-/* global L */
+import L from 'ember-leaflet/L';
 
 const { assert, computed, Component, run, K, A, String: { classify } } = Ember;
 

--- a/addon/helpers/div-icon.js
+++ b/addon/helpers/div-icon.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-/* global L */
+import L from 'ember-leaflet/L';
 
 const { Helper: { helper } } = Ember;
 

--- a/addon/helpers/icon.js
+++ b/addon/helpers/icon.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-/* global L */
+import L from 'ember-leaflet/L';
 
 const { Helper: { helper } } = Ember;
 

--- a/addon/helpers/lat-lng-bounds.js
+++ b/addon/helpers/lat-lng-bounds.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-/* global L */
+import L from 'ember-leaflet/L';
 
 const { Helper: { helper } } = Ember;
 

--- a/addon/helpers/point.js
+++ b/addon/helpers/point.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-/* global L */
+import L from 'ember-leaflet/L';
 
 const { Helper: { helper } } = Ember;
 

--- a/app/initializers/leaflet-assets.js
+++ b/app/initializers/leaflet-assets.js
@@ -1,5 +1,5 @@
 import ENV from '../config/environment';
-/* global L */
+import L from 'ember-leaflet/L';
 
 export function initialize(/* container, application */) {
   L.Icon.Default.imagePath = `${ENV.rootURL || ENV.baseURL || '/'}assets/images/`;

--- a/index.js
+++ b/index.js
@@ -9,6 +9,10 @@ module.exports = {
   included: function(app) {
    this._super.included.apply(this, arguments);
 
+   if (process.env.EMBER_CLI_FASTBOOT) {
+     return;
+   }
+
    // If the addon has the _findHost() method (in ember-cli >= 2.7.0), we'll just
    // use that.
    if (typeof this._findHost === 'function') {
@@ -23,7 +27,7 @@ module.exports = {
    do {
      app = current.app || app;
    } while (current.parent.parent && (current = current.parent));
-    
+
    //import javascript
    app.import(app.bowerDirectory + '/leaflet/dist/leaflet-src.js');
 

--- a/tests/assertions/bounds-contain.js
+++ b/tests/assertions/bounds-contain.js
@@ -1,4 +1,4 @@
-/* global L */
+import L from 'ember-leaflet/L';
 
 export default function boundsContain(bounds1, bounds2, msg = 'Bounds 1 doesn\'t contain bounds 2') {
   // use this.push to add the assertion.

--- a/tests/helpers/locations.js
+++ b/tests/helpers/locations.js
@@ -1,4 +1,5 @@
-/* global L */
+import L from 'ember-leaflet/L';
+
 export default {
   nyc: L.latLng(40.713282, -74.006978),
   sf: L.latLng(37.77493, -122.419415),

--- a/tests/integration/components/geojson-layer-test.js
+++ b/tests/integration/components/geojson-layer-test.js
@@ -4,7 +4,7 @@ import { assertionInjector, assertionCleanup } from '../../assertions';
 import GeoJSONLayerComponent from 'ember-leaflet/components/geojson-layer';
 import locations from '../../helpers/locations';
 import sampleGeoJSON from '../../helpers/sample-geojson';
-/* globals L */
+import L from 'ember-leaflet/L';
 
 const emptyGeoJSON = {
   type: 'FeatureCollection',

--- a/tests/integration/components/leaflet-map-test.js
+++ b/tests/integration/components/leaflet-map-test.js
@@ -3,7 +3,7 @@ import hbs from 'htmlbars-inline-precompile';
 import { assertionInjector, assertionCleanup } from '../../assertions';
 import LeafletMapComponent from 'ember-leaflet/components/leaflet-map';
 import locations from '../../helpers/locations';
-/* global L */
+import L from 'ember-leaflet/L';
 
 let map;
 

--- a/tests/integration/components/marker-collection-test.js
+++ b/tests/integration/components/marker-collection-test.js
@@ -5,7 +5,7 @@ import wait from 'ember-test-helpers/wait';
 import { assertionInjector, assertionCleanup } from '../../assertions';
 import MarkerLayerComponent from 'ember-leaflet/components/marker-layer';
 import locations from '../../helpers/locations';
-/* globals L */
+import L from 'ember-leaflet/L';
 
 const { run } = Ember;
 

--- a/tests/integration/components/marker-layer-test.js
+++ b/tests/integration/components/marker-layer-test.js
@@ -4,7 +4,7 @@ import { assertionInjector, assertionCleanup } from '../../assertions';
 import hasEmberVersion from 'ember-test-helpers/has-ember-version';
 import MarkerLayerComponent from 'ember-leaflet/components/marker-layer';
 import locations from '../../helpers/locations';
-/* globals L */
+import L from 'ember-leaflet/L';
 
 //Needed to silence leaflet autodetection error
 L.Icon.Default.imagePath = 'some-path';

--- a/tests/integration/components/popup-test.js
+++ b/tests/integration/components/popup-test.js
@@ -6,7 +6,7 @@ import wait from 'ember-test-helpers/wait';
 import MarkerLayerComponent from 'ember-leaflet/components/marker-layer';
 import ArrayPathLayerComponent from 'ember-leaflet/components/array-path-layer';
 import locations from '../../helpers/locations';
-/* globals L */
+import L from 'ember-leaflet/L';
 
 const { computed, run, A } = Ember;
 

--- a/tests/integration/components/tooltip-test.js
+++ b/tests/integration/components/tooltip-test.js
@@ -6,7 +6,7 @@ import wait from 'ember-test-helpers/wait';
 import MarkerLayerComponent from 'ember-leaflet/components/marker-layer';
 import ArrayPathLayerComponent from 'ember-leaflet/components/array-path-layer';
 import locations from '../../helpers/locations';
-/* globals L */
+import L from 'ember-leaflet/L';
 
 const { computed, run, A } = Ember;
 

--- a/tests/unit/helpers/div-icon-test.js
+++ b/tests/unit/helpers/div-icon-test.js
@@ -1,6 +1,6 @@
 import { divIcon } from 'dummy/helpers/div-icon';
 import { module, test } from 'qunit';
-/* global L */
+import L from 'ember-leaflet/L';
 
 module('Unit | Helper | div-icon');
 

--- a/tests/unit/helpers/icon-test.js
+++ b/tests/unit/helpers/icon-test.js
@@ -1,6 +1,6 @@
 import { icon } from 'dummy/helpers/icon';
 import { module, test } from 'qunit';
-/* global L */
+import L from 'ember-leaflet/L';
 
 module('Unit | Helper | icon');
 

--- a/tests/unit/helpers/lat-lng-bounds-test.js
+++ b/tests/unit/helpers/lat-lng-bounds-test.js
@@ -1,6 +1,6 @@
 import { latLngBounds } from 'dummy/helpers/lat-lng-bounds';
 import { module, test } from 'qunit';
-/* global L */
+import L from 'ember-leaflet/L';
 
 module('Unit | Helper | lat-lng-bounds');
 

--- a/tests/unit/helpers/point-test.js
+++ b/tests/unit/helpers/point-test.js
@@ -1,6 +1,6 @@
 import { point } from 'dummy/helpers/point';
 import { module, test } from 'qunit';
-/* global L */
+import L from 'ember-leaflet/L';
 
 module('Unit | Helper | point');
 

--- a/tests/unit/initializers/leaflet-assets-test.js
+++ b/tests/unit/initializers/leaflet-assets-test.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 import ENV from '../../../config/environment';
 import { initialize } from '../../../initializers/leaflet-assets';
 import { module, test } from 'qunit';
-/* global L */
+import L from 'ember-leaflet/L';
 
 const { run, Application } = Ember;
 


### PR DESCRIPTION
This PR is related to #74 and #104 but tries to solve the problem from a different perpective:
- Adds a guard to index.js so that leaflet is not loaded in fastboot
- Converts all L globals to a new module
- Provides a dummy implementation of L

Currently, this allows my test app to run under fastboot with no errors.
