### PR TITLE
added the PREPEND configuration option

### DIFF
--- a/app/initializers/leaflet-assets.js
+++ b/app/initializers/leaflet-assets.js
@@ -2,7 +2,7 @@ import ENV from '../config/environment';
 /* global L */
 
 export function initialize(/* container, application */) {
-  L.Icon.Default.imagePath = `${ENV.rootURL || ENV.baseURL || '/'}assets/images/`;
+  L.Icon.Default.imagePath = `${ENV.prepend || ENV.rootURL || ENV.baseURL || '/'}assets/images`;
 }
 
 export default {


### PR DESCRIPTION
Hey, I'm trying to solve #113.

I'm not sure that this would be your solution too, but I've implemented for myself and it seems to work.

As you will notice:

- I'm assuming a `prepend` configuration option to be set, otherwise the fallback will apply as before (I think you're keeping baseURL for backward compatibility, right?)
- I've removed a trailing slash that was causing a "double //" (I don't know ember-leaflet enough to understand if it is somehow needed or it's a "legacy")

So, in my `app/config/environment.js` I've added a piece of code like this:
```
  if (environment === 'production') {
    ENV.prepend = "//mycdn/app/";
  }
```

and I've changed `ember-cli-build.js` as

```
    var config = require('./config/environment')(process.env.EMBER_ENV || 'development');

    fingerprint: {
      extensions: extensions,
      prepend: config.prepend,
      ...
      
```
