### PR TITLE
support empty rootURL

### DIFF
--- a/app/initializers/browser/leaflet-assets.js
+++ b/app/initializers/browser/leaflet-assets.js
@@ -2,7 +2,7 @@ import config from 'ember-get-config';
 /* global L */
 
 export function initialize(/* container, application */) {
-  L.Icon.Default.imagePath = `${config.rootURL || config.baseURL || '/'}assets/images/`;
+  L.Icon.Default.imagePath = `${config.rootURL || config.baseURL || ''}assets/images/`;
 }
 
 export default {

--- a/tests/unit/initializers/browser/leaflet-assets-test.js
+++ b/tests/unit/initializers/browser/leaflet-assets-test.js
@@ -44,3 +44,10 @@ test('it sets icon default imagePath with rootURL', function(assert) {
 
   assert.equal(L.Icon.Default.imagePath, '/path/to/root/assets/images/');
 });
+
+test('it supports empty rootURL', function(assert) {
+  ENV.rootURL = '';
+  initialize(registry, application);
+
+  assert.equal(L.Icon.Default.imagePath, 'assets/images/');
+});


### PR DESCRIPTION
One of our environments uses an empty rootURL (`ENV.rootURL = '';` in `config/environment.js`)

We found that ember-leaflet didn't respect this setting; it would use `'/'` instead, which breaks a couple of the marker asset paths.

I implemented the simplest possible fix for this, but we can discuss more complex logic if you're interested in trying to maintain backward compatibility for users of ember-leaflet that somehow depended on the previous fallback `'/'` behavior.

(for what it's worth, `ember init` generates fresh projects with `rootURL = '/'`)