### PR TITLE
Add exclude options for leaflet dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### master
 - [BUGFIX] Allow `rootURL` to be an empty string. Try to mimic the same defaults as ember-cli.
+- [ENHANCEMENT] Add exclude options for leaflet dependencies ([#134](https://github.com/miguelcobain/ember-leaflet/pull/134))
 
 ### 3.0.9
 - [BUGFIX] moved ember-get-config dependency to `dependencies`

--- a/index.js
+++ b/index.js
@@ -14,6 +14,9 @@ module.exports = {
   included: function(app) {
     this._super.included.apply(this, arguments);
 
+    // Addon options from the apps ember-cli-build.js
+    var options = app.options[this.name] || {};
+
     // If the addon has the _findHost() method (in ember-cli >= 2.7.0), we'll just
     // use that.
     if (typeof this._findHost === 'function') {
@@ -30,18 +33,24 @@ module.exports = {
     } while (current.parent.parent && (current = current.parent));
 
     // import javascript only if not in fastboot
-    if (!process.env.EMBER_CLI_FASTBOOT) {
+    if (!options.excludeJS && !process.env.EMBER_CLI_FASTBOOT) {
       app.import(app.bowerDirectory + '/leaflet/dist/leaflet-src.js');
     }
 
-    app.import(app.bowerDirectory + '/leaflet/dist/leaflet.css');
+    // Import leaflet css
+    if (!options.excludeCSS) {
+      app.import(app.bowerDirectory + '/leaflet/dist/leaflet.css');
+    }
 
-    var imagesDestDir = '/assets/images';
-    app.import(app.bowerDirectory + '/leaflet/dist/images/layers-2x.png', { destDir: imagesDestDir });
-    app.import(app.bowerDirectory + '/leaflet/dist/images/layers.png', { destDir: imagesDestDir });
-    app.import(app.bowerDirectory + '/leaflet/dist/images/marker-icon-2x.png', { destDir: imagesDestDir });
-    app.import(app.bowerDirectory + '/leaflet/dist/images/marker-icon.png', { destDir: imagesDestDir });
-    app.import(app.bowerDirectory + '/leaflet/dist/images/marker-shadow.png', { destDir: imagesDestDir });
+    // Import leaflet images
+    if (!options.excludeImages) {
+      var imagesDestDir = '/assets/images';
+      app.import(app.bowerDirectory + '/leaflet/dist/images/layers-2x.png', { destDir: imagesDestDir });
+      app.import(app.bowerDirectory + '/leaflet/dist/images/layers.png', { destDir: imagesDestDir });
+      app.import(app.bowerDirectory + '/leaflet/dist/images/marker-icon-2x.png', { destDir: imagesDestDir });
+      app.import(app.bowerDirectory + '/leaflet/dist/images/marker-icon.png', { destDir: imagesDestDir });
+      app.import(app.bowerDirectory + '/leaflet/dist/images/marker-shadow.png', { destDir: imagesDestDir });
+    }
  },
 
  treeForAddonTemplates: function treeForAddonTemplates (tree) {


### PR DESCRIPTION
Nice to have options, so that users of the addon can opt out of including the lealfet dependencies in favor of versions they choose to include themselves. For example the leaflet css contains some visual tweaks that might make it annoying to have to override. In order to use just add the desired options in the `ember-cli-build.js` file:
```
var app = new EmberApp(defaults, {
  'ember-leaflet': {
    excludeCSS: true,
    excludeImages: true,
    excludeJS: true,
  },
});
```