### PR TITLE
Remove tagName: ''

### DIFF
--- a/addon/components/base-layer.js
+++ b/addon/components/base-layer.js
@@ -16,7 +16,6 @@ const {
 const leaf = typeof L === 'undefined' ? {} : L;
 
 export default Component.extend(ChildMixin, InvokeActionMixin, {
-  tagName: '',
   L: leaf,
 
   fastboot: computed(function() {


### PR DESCRIPTION
tag-less components results in severe problem when used with ember >2.8.0: 
"Assertion Failed: You cannot use `attributeBindings` on a tag-less component: <package@component:tile-layer::ember4710>"