### PR TITLE
only Render tooltip if still "shouldRender"

### DIFF
--- a/addon/components/tooltip-layer.js
+++ b/addon/components/tooltip-layer.js
@@ -53,7 +53,9 @@ export default DivOverlayLayer.extend({
       this.set('shouldRender', true);
       // ember-wormhole will render on the afterRender queue, so we need to render after that
       run.next(() => {
-        oldOnAdd.call(this._layer, map);
+        if (this.get('shouldRender')) {
+          oldOnAdd.call(this._layer, map);
+        }
       });
     };
     // we need to user `layerremove` event becase it's the only one that fires


### PR DESCRIPTION
Because this is called in the next run loop sometimes 'shouldRender' is false and the tooltip's getPane method fails.

This doesn't happen often, I could only reproduce having 5000+ shapes in the map and hover quickly over many of them.
