### PR TITLE
export Leaflet object, public components and toLatLng macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### master
 - [ENHANCEMENT] leaflet-map: pass more options and observe `minZoom`, `maxZoom` ([#142](https://github.com/miguelcobain/ember-leaflet/pull/142), [#144](https://github.com/miguelcobain/ember-leaflet/pull/144))
 - [DEPRECATION] [ENHANCEMENT] image-layer: `imageUrl` attribute is deprecated in favor of the observed `url` attribute ([#143](https://github.com/miguelcobain/ember-leaflet/pull/143))
+- [ENHANCEMENT] Public components, the `toLatLng` macro and the `Leaflet` library itself are now exported by this addon ([#141](https://github.com/miguelcobain/ember-leaflet/pull/141))
 
 ### 3.0.10
 - [BUGFIX] Allow `rootURL` to be an empty string. Try to mimic the same defaults as ember-cli.

--- a/addon/index.js
+++ b/addon/index.js
@@ -1,0 +1,28 @@
+const L = window.L || {};
+export { L, L as Leaflet };
+
+export { default as CircleLayer } from 'ember-leaflet/components/circle-layer';
+
+export { default as CircleMarkerLayer } from 'ember-leaflet/components/circle-marker-layer';
+
+export { default as GeojsonLayer } from 'ember-leaflet/components/geojson-layer';
+
+export { default as ImageLayer } from 'ember-leaflet/components/image-layer';
+
+export { default as LeafletMap } from 'ember-leaflet/components/leaflet-map';
+
+export { default as MarkerLayer } from 'ember-leaflet/components/marker-layer';
+
+export { default as PolygonLayer } from 'ember-leaflet/components/polygon-layer';
+
+export { default as PolylineLayer } from 'ember-leaflet/components/polyline-layer';
+
+export { default as PopupLayer } from 'ember-leaflet/components/popup-layer';
+
+export { default as TileLayer } from 'ember-leaflet/components/tile-layer';
+
+export { default as TooltipLayer } from 'ember-leaflet/components/tooltip-layer';
+
+export { default as WmsTileLayer } from 'ember-leaflet/components/wms-tile-layer';
+
+export { default as toLatLng } from 'ember-leaflet/macros/to-lat-lng';


### PR DESCRIPTION
Accessing the Leaflet object (`L`) is currently only possible like so:

```js
const L = window.L;
```

Whereas this PR enables importing Leaflet from the addon package.

```js
import L from 'ember-leaflet';
```

When #106 lands this obviously would need adaption.