### PR TITLE
leaflet-map: pass more options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # ember-leaflet changelog
 
+### master
+- [ENHANCEMENT] leaflet-map: pass more options and observe `minZoom`, `maxZoom` ([#142](https://github.com/miguelcobain/ember-leaflet/pull/142))
+
 ### 3.0.10
 - [BUGFIX] Allow `rootURL` to be an empty string. Try to mimic the same defaults as ember-cli.
 - [ENHANCEMENT] Add exclude options for leaflet dependencies ([#134](https://github.com/miguelcobain/ember-leaflet/pull/134))

--- a/addon/components/leaflet-map.js
+++ b/addon/components/leaflet-map.js
@@ -21,6 +21,7 @@ export default BaseLayer.extend(ParentMixin, {
     'keyboard', 'keyboardPanOffset', 'keyboardZoomOffset',
     // Panning Inertia Options
     'inertia', 'inertiaDeceleration', 'inertiaMaxSpeed', 'inertiaThreshold',
+    'easeLinearity', 'worldCopyJump', 'maxBoundsViscosity',
     // Control options
     'zoomControl', 'attributionControl',
     // Animation options
@@ -39,7 +40,9 @@ export default BaseLayer.extend(ParentMixin, {
   ],
 
   leafletProperties: [
-    'zoom:setZoom:zoomPanOptions', 'center:panTo:zoomPanOptions', 'maxBounds:setMaxBounds', 'bounds:fitBounds:fitBoundsOptions'
+    'zoom:setZoom:zoomPanOptions', 'minZoom', 'maxZoom',
+    'center:panTo:zoomPanOptions',
+    'bounds:fitBounds:fitBoundsOptions', 'maxBounds'
   ],
 
   center: toLatLng(),


### PR DESCRIPTION
This PR adds missing options to `{{leaflet-map}}`:

- `easeLinearity`
- `worldCopyJump`
- `maxBoundsViscosity`

It also enables observers for `minZoom` and `maxZoom`.