### PR TITLE
image-layer: improve bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### master
 - [ENHANCEMENT] leaflet-map: pass more options and observe `minZoom`, `maxZoom` ([#142](https://github.com/miguelcobain/ember-leaflet/pull/142), [#144](https://github.com/miguelcobain/ember-leaflet/pull/144))
+- [DEPRECATION] [ENHANCEMENT] image-layer: `imageUrl` attribute is deprecated in favor of the observed `url` attribute ([#143](https://github.com/miguelcobain/ember-leaflet/pull/143))
 
 ### 3.0.10
 - [BUGFIX] Allow `rootURL` to be an empty string. Try to mimic the same defaults as ember-cli.

--- a/addon/components/image-layer.js
+++ b/addon/components/image-layer.js
@@ -11,7 +11,7 @@ export default BaseLayer.extend({
   ],
 
   leafletProperties: [
-    'url', 'opacity'
+    'url', 'opacity', 'bounds'
   ],
 
   createLayer() {

--- a/addon/components/image-layer.js
+++ b/addon/components/image-layer.js
@@ -11,7 +11,7 @@ export default BaseLayer.extend({
   ],
 
   leafletProperties: [
-    'url', 'opacity', 'bounds'
+    'url', 'imageUrl:setUrl', 'opacity', 'bounds'
   ],
 
   createLayer() {

--- a/addon/components/image-layer.js
+++ b/addon/components/image-layer.js
@@ -1,9 +1,15 @@
+import Ember from 'ember';
 import BaseLayer from 'ember-leaflet/components/base-layer';
+
+const {
+  deprecate,
+  isPresent
+} = Ember;
 
 export default BaseLayer.extend({
 
   leafletRequiredOptions: [
-    'imageUrl', 'bounds'
+    'url', 'bounds'
   ],
 
   leafletOptions: [
@@ -11,8 +17,26 @@ export default BaseLayer.extend({
   ],
 
   leafletProperties: [
-    'url', 'imageUrl:setUrl', 'opacity', 'bounds'
+    'url', 'opacity', 'bounds'
   ],
+
+  init() {
+    let imageUrl = this.get('imageUrl');
+    if (isPresent(imageUrl)) {
+      deprecate(
+        'ember-leaflet/image-layer: The `imageUrl` attribute has been deprecated in favor of the observed attribute `url`.',
+        false,
+        {
+          id:    'ember-leaflet.image-layer.imageUrl',
+          until: '4.0.0',
+          url:   'https://github.com/miguelcobain/ember-leaflet/pull/143'
+        }
+      );
+      this.set('url', imageUrl);
+    }
+
+    this._super(...arguments);
+  },
 
   createLayer() {
     return this.L.imageOverlay(...this.get('requiredOptions'), this.get('options'));


### PR DESCRIPTION
#### `bounds` observer

Currently `bounds` is not observed for changes, as there is not `setBounds` method documented on the official website yet. However, a `setBounds` method exists and is public, as can be seen here: https://github.com/Leaflet/Leaflet/issues/5150

This PR adds a `bounds` observer accordingly.

#### `imageUrl` observer

Currently, changing the `imageUrl` is only possible via the `url` attribute, although the initial URL must be provided via `imageUrl`, which results in this ugly code:

```hbs
{{image-layer
  imageUrl=objectURL
  url=objectURL
  bounds=bounds
}}
```

This PR adds a proper observer for `imageUrl`, effectively removing the need to pass the image URL twice. The old `url` observer is kept for backwards compatibility.