### PR TITLE
leaflet-map: add wheelPxPerZoomLevel, zoomDelta, zoomSnap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # ember-leaflet changelog
 
 ### master
-- [ENHANCEMENT] leaflet-map: pass more options and observe `minZoom`, `maxZoom` ([#142](https://github.com/miguelcobain/ember-leaflet/pull/142))
+- [ENHANCEMENT] leaflet-map: pass more options and observe `minZoom`, `maxZoom` ([#142](https://github.com/miguelcobain/ember-leaflet/pull/142), [#144](https://github.com/miguelcobain/ember-leaflet/pull/144))
 
 ### 3.0.10
 - [BUGFIX] Allow `rootURL` to be an empty string. Try to mimic the same defaults as ember-cli.

--- a/addon/components/leaflet-map.js
+++ b/addon/components/leaflet-map.js
@@ -16,7 +16,7 @@ export default BaseLayer.extend(ParentMixin, {
     // Interaction options
     'dragging', 'touchZoom', 'scrollWheelZoom', 'doubleClickZoom', 'boxZoom',
     'tap', 'tapTolerance', 'trackResize', 'worldCopyJump', 'closePopupOnClick',
-    'bounceAtZoomLimits',
+    'bounceAtZoomLimits', 'wheelPxPerZoomLevel', 'zoomDelta', 'zoomSnap',
     // Keyboard navigation options
     'keyboard', 'keyboardPanOffset', 'keyboardZoomOffset',
     // Panning Inertia Options


### PR DESCRIPTION
Follow up on #142.

While working on our app, I noticed that these properties were missing as well.

---

By the way, a **huge** thank you from my colleagues and myself for offering this awesome addon! :heart:   
We're (ab-)using `ember-leaflet` for displaying a document viewer with highlighting and marker support.  