### PR TITLE
fix: Prevent error happening when _removeStyleObservers is called mul…

### DIFF
--- a/addon/mixins/style.js
+++ b/addon/mixins/style.js
@@ -32,6 +32,10 @@ export default Mixin.create({
   },
 
   _removeStyleObservers() {
+    if (!this._styleObservers) {
+      return;
+    }
+
     this.get('leafletStyleProperties').forEach(function(property) {
       this.removeObserver(property, this, this._styleObservers[property]);
       delete this._styleObservers[property];


### PR DESCRIPTION
…tiple times on the same object

Resolves #152, but is not the real underlying solution, since that is somewhere in composability-tools. This is a stop-gap solution, which is needed because it breaks apps otherwise.