### PR TITLE
Fixes errors when being used with leaflet marker cluster

### DIFF
--- a/addon/components/marker-layer.js
+++ b/addon/components/marker-layer.js
@@ -36,6 +36,7 @@ export default BaseLayer.extend(DraggabilityMixin, DivOverlayableMixin, {
   // leaflet bug where draggability is lost on icon change
   iconDidChange: observer('icon', function() {
     this._layer.setIcon(this.get('icon'));
+    if (!this._layer.dragging) { return; }
 
     if (this.get('draggable')) {
       this._layer.dragging.enable();

--- a/addon/components/popup-layer.js
+++ b/addon/components/popup-layer.js
@@ -97,11 +97,13 @@ export default DivOverlayLayer.extend({
     // we need to user `layerremove` event becase it's the only one that fires
     // *after* the popup was completely removed from the map
     let parentComponent = this.get('parentComponent');
-    parentComponent._layer._map.addEventListener('layerremove', this._onLayerRemove, this);
+    let map = parentComponent._layer._map;
+    map && map.addEventListener('layerremove', this._onLayerRemove, this);
   },
 
   _removePopupListeners() {
     let parentComponent = this.get('parentComponent');
-    parentComponent._layer._map.removeEventListener('layerremove', this._onLayerRemove, this);
+    let map = parentComponent._layer._map;
+    map && map.removeEventListener('layerremove', this._onLayerRemove, this);
   }
 });

--- a/addon/components/tooltip-layer.js
+++ b/addon/components/tooltip-layer.js
@@ -59,11 +59,13 @@ export default DivOverlayLayer.extend({
     // we need to user `layerremove` event becase it's the only one that fires
     // *after* the popup was completely removed from the map
     let parentComponent = this.get('parentComponent');
-    parentComponent._layer._map.addEventListener('layerremove', this._onLayerRemove, this);
+    let map = parentComponent._layer._map;
+    map && map.addEventListener('layerremove', this._onLayerRemove, this);
   },
 
   _removePopupListeners() {
     let parentComponent = this.get('parentComponent');
-    parentComponent._layer._map.removeEventListener('layerremove', this._onLayerRemove, this);
+    let map = parentComponent._layer._map;
+    map && map.removeEventListener('layerremove', this._onLayerRemove, this);
   }
 });


### PR DESCRIPTION
```
tooltip-layer.js:61 Uncaught TypeError: Cannot read property 'addEventListener' of undefined
    at Class._addPopupListeners (tooltip-layer.js:61)
    at Class.didCreateLayer (tooltip-layer.js:20)
    at Class.didInsertParent (base-layer.js:109)
    at applyStr (ember-utils.js:522)
    at tryInvoke (ember-utils.js:584)
    at Class.registerChild (parent.js:77)
    at Class.registerWithParent (child.js:55)
    at Class.initChild (child.js:21)
    at applyStr (ember-utils.js:522)
    at tryInvoke (ember-utils.js:584)
```