### PR TITLE
This closes #181

### DIFF
--- a/addon/components/geojson-layer.js
+++ b/addon/components/geojson-layer.js
@@ -29,7 +29,10 @@ export default BaseLayer.extend(DivOverlayableMixin, StyleMixin, {
   didUpdateAttrs() {
     this._super(...arguments);
 
-    let geoJSON = this.get('geoJSON');
+    let { geoJSON, style } = this.getProperties('geoJSON', 'style');
+
+    this.updateStyle(style);
+
     if (geoJSON) {
       this.pushDataToLeaflet(geoJSON);
     }
@@ -48,6 +51,14 @@ export default BaseLayer.extend(DivOverlayableMixin, StyleMixin, {
       // ...then add new data to recreate the child layers in an updated form
       this._layer.addData(geoJSON);
     }
+  },
+
+  updateStyle(style) {
+    if (!this._layer) {
+      return;
+    }
+
+    this._layer.options.style = style;
   },
 
   createLayer() {


### PR DESCRIPTION
This updates the layer options of the GeoJSON layer in the didUpdateAttrs() hook when the style attribute changes. It looks like the current implementation always clears and re-adds all features when any of the attributes is updated. I think considerable performance improvements could be made by changing layer content only when the geoJSON attribute changes, and updating the styles of the child layers in all other cases. I could help with the implementation, if desired.