### PR TITLE
Added usable property for overriding the noRedraw leaflet option

### DIFF
--- a/addon/components/tile-layer.js
+++ b/addon/components/tile-layer.js
@@ -10,7 +10,7 @@ export default BaseLayer.extend({
     'minZoom', 'maxZoom', 'maxNativeZoom', 'tileSize', 'subdomains',
     'errorTileUrl', 'attribution', 'tms', 'continuousWorld', 'noWrap',
     'zoomOffset', 'zoomReverse', 'opacity', 'zIndex', 'unloadInvisibleTiles',
-    'updateWhenIdle', 'detectRetina', 'reuseTiles', 'bounds', 'className', 'noRedraw'
+    'updateWhenIdle', 'detectRetina', 'reuseTiles', 'bounds', 'className'
   ]),
 
   leafletEvents: Object.freeze([

--- a/addon/components/tile-layer.js
+++ b/addon/components/tile-layer.js
@@ -10,7 +10,7 @@ export default BaseLayer.extend({
     'minZoom', 'maxZoom', 'maxNativeZoom', 'tileSize', 'subdomains',
     'errorTileUrl', 'attribution', 'tms', 'continuousWorld', 'noWrap',
     'zoomOffset', 'zoomReverse', 'opacity', 'zIndex', 'unloadInvisibleTiles',
-    'updateWhenIdle', 'detectRetina', 'reuseTiles', 'bounds', 'className'
+    'updateWhenIdle', 'detectRetina', 'reuseTiles', 'bounds', 'className', 'noRedraw'
   ]),
 
   leafletEvents: Object.freeze([
@@ -18,7 +18,7 @@ export default BaseLayer.extend({
   ]),
 
   leafletProperties: Object.freeze([
-    'url', 'zIndex', 'opacity'
+    'url:setUrl:noRedraw', 'zIndex', 'opacity'
   ]),
 
   createLayer() {


### PR DESCRIPTION
My initial thought for this was to handle the redraw after all the tile network calls were made and resolved then redraw on `onLoad` and avoid the split second where it switches images, but that was unsuccessful, nevertheless someone may need to have the layer not redraw on url change.