### PR TITLE
fix: add missing video-layer reexport

### DIFF
--- a/app/components/video-layer.js
+++ b/app/components/video-layer.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-leaflet/components/video-layer';


### PR DESCRIPTION
This makes the addon usable again for versions after video-layer was introduced.