### PR TITLE
Add ember-leaflet-fullscreen-control addon.

### DIFF
--- a/tests/dummy/app/templates/addons.hbs
+++ b/tests/dummy/app/templates/addons.hbs
@@ -92,6 +92,10 @@
         <a href="https://github.com/transitland/ember-leaflet-polyline-decorator">ember-leaflet-polyline-decorator</a> - Ember Leaflet Addon for L.PolylineDecorator
       </li>
       
+      <li>
+        <a href="https://github.com/evocount/ember-leaflet-fullscreen-control">ember-leaflet-fullscreen-control</a> - Ember Leaflet Addon for leaflet.fullscreen
+      </li>
+      
     </ul>
   </section>
 </section>


### PR DESCRIPTION
Adds an addon bringing leaflet.fullscreen to ember-leaflet to list of addons in docs.