### PR TITLE
Add ember-leaflet-pm addon.

### DIFF
--- a/tests/dummy/app/templates/addons.hbs
+++ b/tests/dummy/app/templates/addons.hbs
@@ -75,25 +75,29 @@
       <li>
         <a href="https://github.com/StevenHeinrich/ember-leaflet-draw">ember-leaflet-draw</a> - Provides feature drawing functionality and a Drawing Control for Ember-Leaflet
       </li>
-      
+
       <li>
         <a href="https://github.com/willviles/ember-leaflet-heatmap">ember-leaflet-heatmap</a> - Offers Heatmap.js functionality for Ember-Leaflet
       </li>
-  
+
       <li>
         <a href="https://github.com/dio-el-claire/ember-leaflet-heatmap-layer">ember-leaflet-heatmap-layer</a> - Another Heatmap.js wrapper for Ember-Leaflet
       </li>
-      
+
       <li>
         <a href="https://github.com/dio-el-claire/ember-leaflet-google-mutant-layer">ember-leaflet-google-mutant-layer</a> - New Google's tile layers with TrafficLayer and other google layers support for ember-leaflet
       </li>
-      
+
       <li>
         <a href="https://github.com/transitland/ember-leaflet-polyline-decorator">ember-leaflet-polyline-decorator</a> - Ember Leaflet Addon for L.PolylineDecorator
       </li>
-      
+
       <li>
         <a href="https://github.com/evocount/ember-leaflet-fullscreen-control">ember-leaflet-fullscreen-control</a> - Ember Leaflet Addon for leaflet.fullscreen
+      </li>
+
+      <li>
+        <a href="https://github.com/evocount/ember-leaflet-pm">ember-leaflet-pm</a> - Ember Leaflet Addon for leaflet.pm
       </li>
       
     </ul>


### PR DESCRIPTION
Adds an addon bringing leaflet.pm to ember-leaflet to list of addons in docs.