### PR TITLE
FIX yielded components

### DIFF
--- a/addon/templates/current/leaflet-map.hbs
+++ b/addon/templates/current/leaflet-map.hbs
@@ -25,7 +25,7 @@
       onChange=(action (mut mergedComponents))}}
   {{/each}}
 
-  {{yield mergedComponents}}
+  {{yield components}}
 {{/let}}
 
 {{!--


### PR DESCRIPTION
Yielding mergedComponents will leave the widget layerless unless an addon is registered.