### PR TITLE
Replace volatile computed property with function

### DIFF
--- a/addon/components/base-layer.js
+++ b/addon/components/base-layer.js
@@ -91,7 +91,7 @@ export default Component.extend(ChildMixin, InvokeActionMixin, {
     this.get('parentComponent')._layer.removeLayer(this._layer);
   },
 
-  options: computed(function() {
+  options() {
     let leafletOptions = this.get('leafletOptions');
     let options = {};
     leafletOptions.forEach((optionName) => {
@@ -100,7 +100,7 @@ export default Component.extend(ChildMixin, InvokeActionMixin, {
       }
     });
     return options;
-  }).volatile(),
+  },
 
   leafletRequiredOptions: A(),
 

--- a/addon/components/circle-layer.js
+++ b/addon/components/circle-layer.js
@@ -11,6 +11,6 @@ export default PointPathLayer.extend({
   ]),
 
   createLayer() {
-    return this.L.circle(...this.get('requiredOptions'), this.get('options'));
+    return this.L.circle(...this.get('requiredOptions'), this.options());
   }
 });

--- a/addon/components/circle-marker-layer.js
+++ b/addon/components/circle-marker-layer.js
@@ -11,6 +11,6 @@ export default PointPathLayer.extend({
   ]),
 
   createLayer() {
-    return this.L.circleMarker(...this.get('requiredOptions'), this.get('options'));
+    return this.L.circleMarker(...this.get('requiredOptions'), this.options());
   }
 });

--- a/addon/components/geojson-layer.js
+++ b/addon/components/geojson-layer.js
@@ -50,7 +50,7 @@ export default BaseLayer.extend(DivOverlayableMixin, StyleMixin, {
 
     // we need to update the group layers options before re-adding geojson
     // otherwise, they wouldn't get the changes that could be happening meanwhile
-    this._layer.options = this.get('options');
+    this._layer.options = this.options();
 
     if (geoJSON) {
       // ...then add new data to recreate the child layers in an updated form
@@ -59,6 +59,6 @@ export default BaseLayer.extend(DivOverlayableMixin, StyleMixin, {
   },
 
   createLayer() {
-    return this.L.geoJson(...this.get('requiredOptions'), this.get('options'));
+    return this.L.geoJson(...this.get('requiredOptions'), this.options());
   }
 });

--- a/addon/components/image-layer.js
+++ b/addon/components/image-layer.js
@@ -40,6 +40,6 @@ export default InteractiveLayer.extend({
   },
 
   createLayer() {
-    return this.L.imageOverlay(...this.get('requiredOptions'), this.get('options'));
+    return this.L.imageOverlay(...this.get('requiredOptions'), this.options());
   }
 });

--- a/addon/components/leaflet-map.js
+++ b/addon/components/leaflet-map.js
@@ -59,7 +59,7 @@ export default BaseLayer.extend(ParentMixin, {
   unregisterWithParent() { },
 
   createLayer() {
-    let options = this.get('options');
+    let options = this.options();
 
     // Don't set center and zoom right now.
     // Let base layer bind the events first

--- a/addon/components/marker-layer.js
+++ b/addon/components/marker-layer.js
@@ -27,7 +27,7 @@ export default InteractiveLayer.extend(DraggabilityMixin, DivOverlayableMixin, {
   location: toLatLng(),
 
   createLayer() {
-    return this.L.marker(...this.get('requiredOptions'), this.get('options'));
+    return this.L.marker(...this.get('requiredOptions'), this.options());
   },
 
   // icon observer separated from generated (leaflet properties) due to a

--- a/addon/components/polygon-layer.js
+++ b/addon/components/polygon-layer.js
@@ -2,6 +2,6 @@ import PolylineLayer from 'ember-leaflet/components/polyline-layer';
 
 export default PolylineLayer.extend({
   createLayer() {
-    return this.L.polygon(...this.get('requiredOptions'), this.get('options'));
+    return this.L.polygon(...this.get('requiredOptions'), this.options());
   }
 });

--- a/addon/components/polyline-layer.js
+++ b/addon/components/polyline-layer.js
@@ -6,6 +6,6 @@ export default ArrayPathLayer.extend({
   ]),
 
   createLayer() {
-    return this.L.polyline(...this.get('requiredOptions'), this.get('options'));
+    return this.L.polyline(...this.get('requiredOptions'), this.options());
   }
 });

--- a/addon/components/popup-layer.js
+++ b/addon/components/popup-layer.js
@@ -44,7 +44,7 @@ export default DivOverlayLayer.extend({
   },
 
   createLayer() {
-    return this.L.popup(this.get('options')).setContent(this.get('destinationElement'));
+    return this.L.popup(this.options()).setContent(this.get('destinationElement'));
   },
 
   didCreateLayer() {

--- a/addon/components/tile-layer.js
+++ b/addon/components/tile-layer.js
@@ -22,6 +22,6 @@ export default BaseLayer.extend({
   ]),
 
   createLayer() {
-    return this.L.tileLayer(...this.get('requiredOptions'), this.get('options'));
+    return this.L.tileLayer(...this.get('requiredOptions'), this.options());
   }
 });

--- a/addon/components/tooltip-layer.js
+++ b/addon/components/tooltip-layer.js
@@ -12,7 +12,7 @@ export default DivOverlayLayer.extend({
   shouldRender: reads('permanent'),
 
   createLayer() {
-    return this.L.tooltip(this.get('options')).setContent(this.get('destinationElement'));
+    return this.L.tooltip(this.options()).setContent(this.get('destinationElement'));
   },
 
   didCreateLayer() {

--- a/addon/components/video-layer.js
+++ b/addon/components/video-layer.js
@@ -15,6 +15,6 @@ export default ImageLayer.extend({
   ]),
 
   createLayer() {
-    return this.L.videoOverlay(...this.get('requiredOptions'), this.get('options'));
+    return this.L.videoOverlay(...this.get('requiredOptions'), this.options());
   }
 });

--- a/addon/components/wms-tile-layer.js
+++ b/addon/components/wms-tile-layer.js
@@ -7,7 +7,7 @@ export default TileLayer.extend({
   ]),
 
   createLayer() {
-    return this.L.tileLayer.wms(...this.get('requiredOptions'), this.get('options'));
+    return this.L.tileLayer.wms(...this.get('requiredOptions'), this.options());
   }
 
 });

--- a/tests/integration/components/array-path-layer-test.js
+++ b/tests/integration/components/array-path-layer-test.js
@@ -24,7 +24,7 @@ module('Integration | Component | array path layer', function(hooks) {
         arrayPath = this;
       },
       createLayer() {
-        return this.L.polyline(...this.get('requiredOptions'), this.get('options'));
+        return this.L.polyline(...this.get('requiredOptions'), this.options());
       }
     }));
 

--- a/tests/integration/components/point-path-layer-test.js
+++ b/tests/integration/components/point-path-layer-test.js
@@ -23,7 +23,7 @@ module('Integration | Component | point path layer', function(hooks) {
         pointPath = this;
       },
       createLayer() {
-        return this.L.circle(this.get('location'), 50, this.get('options'));
+        return this.L.circle(this.get('location'), 50, this.options());
       }
     }));
 

--- a/tests/integration/components/popup-test.js
+++ b/tests/integration/components/popup-test.js
@@ -39,7 +39,7 @@ module('Integration | Component | popup layer', function(hooks) {
         arrayPath = this;
       },
       createLayer() {
-        return this.L.polyline(...this.get('requiredOptions'), this.get('options'));
+        return this.L.polyline(...this.get('requiredOptions'), this.options());
       }
     }));
 

--- a/tests/integration/components/tooltip-test.js
+++ b/tests/integration/components/tooltip-test.js
@@ -40,7 +40,7 @@ if (!isLeaflet07(L)) {
           arrayPath = this;
         },
         createLayer() {
-          return this.L.polyline(...this.get('requiredOptions'), this.get('options'));
+          return this.L.polyline(...this.get('requiredOptions'), this.options());
         }
       }));
 


### PR DESCRIPTION
As mentioned in #305, `volatile()` is now [deprecated](https://deprecations.emberjs.com/v3.x/#toc_computed-property-volatile) for computed properties. While the suggested fix is to use a getter, that wouldn’t work for older Ember versions. So I chose to use a function directly.

I’m not sure, though, whether `this.options` is considered part of the public interface; if so, this approach would be a breaking change. I’m open to suggestions of another technique that preserves backward compatibility if you prefer! Maybe `this.set('options', …)` in `#init`?

Thanks for this library, it’s excellent when I get to use it 😀