### PR TITLE
Move volatile computed property setting to init

### DIFF
--- a/addon/components/base-layer.js
+++ b/addon/components/base-layer.js
@@ -15,6 +15,20 @@ export default Component.extend(ChildMixin, InvokeActionMixin, {
   tagName: '',
   L: leaf,
 
+  init() {
+    this._super(...arguments);
+
+    let leafletOptions = this.get('leafletOptions');
+    let options = {};
+    leafletOptions.forEach((optionName) => {
+      if (this.get(optionName) !== undefined) {
+        options[optionName] = this.get(optionName);
+      }
+    });
+
+    this.set('options', options);
+  },
+
   fastboot: computed(function() {
     let owner = getOwner(this);
     return owner.lookup('service:fastboot');
@@ -90,17 +104,6 @@ export default Component.extend(ChildMixin, InvokeActionMixin, {
   removeFromContainer() {
     this.get('parentComponent')._layer.removeLayer(this._layer);
   },
-
-  options: computed(function() {
-    let leafletOptions = this.get('leafletOptions');
-    let options = {};
-    leafletOptions.forEach((optionName) => {
-      if (this.get(optionName) !== undefined) {
-        options[optionName] = this.get(optionName);
-      }
-    });
-    return options;
-  }).volatile(),
 
   leafletRequiredOptions: A(),
 


### PR DESCRIPTION
This is an alternate approach to #313. The `mouseover`/`mouseleave` tests for the `GeoJSONLayer` component are failing though… I’m not sure if this is also a breaking change 🤔