### PR TITLE
Move version-dependent template inclusion

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,19 +66,22 @@ module.exports = {
     }
   },
 
-  treeForAddonTemplates() {
+  treeForAddon(tree) {
     let checker = new VersionChecker(this);
     let dep = checker.for('ember', 'bower');
 
-    let baseTemplatesPath = path.join(this.root, 'addon/templates');
+    let templatesTree;
 
     if (dep.lt('2.3.0-beta.1')) {
-      let current = this.treeGenerator(path.join(baseTemplatesPath, 'current'));
-      let specificVersionTemplate = this.treeGenerator(path.join(baseTemplatesPath, 'lt-2-3'));
-      return mergeTrees([current, specificVersionTemplate], { overwrite: true });
+      templatesTree = new Funnel(tree, {srcDir: 'templates/lt-2-3', destDir: 'templates'});
     } else {
-      return this.treeGenerator(path.join(baseTemplatesPath, 'current'));
+      templatesTree = new Funnel(tree, {srcDir: 'templates/current', destDir: 'templates'});
     }
+
+    let treeWithoutTemplates = new Funnel(tree, {exclude: ['**/templates/**']});
+    let treeWithVersionedTemplates = mergeTrees([templatesTree, treeWithoutTemplates]);
+
+    return this._super.treeForAddon.apply(this, [treeWithVersionedTemplates]);
   },
 
   pathBase(packageName) {


### PR DESCRIPTION
This closes #316. As described in ember-cli/ember-cli#8693,
treeForAddonTemplates is being removed. Since treeForAddon
wasn’t being used in Ember Leaflet, I moved the template-
filtering into it, with path-based adjustments.

In the repository I created to document the Ember CLI issue, you can see that when I made [this commit](https://github.com/backspace/ember-cli-8633-ember-leaflet/commit/778809cb5806893d2e120ec0d62d9e983fc6d9f5) to change to the problematic version of Ember CLI but also this fork, that the test passes.

I tried creating a pre-2.3 Ember CLI application to exercise the other branch in the conditional but I [couldn’t get it running](https://travis-ci.com/backspace/ember-cli-2point2-8633-ember-leaflet/jobs/228042070) 😞

One thing I’m not sure about is whether I should have preserved the use of `path.join`, maybe for Windows reasons?