### PR TITLE
run initializer code only if leaflet's-L variable is present

### DIFF
--- a/addon/initializers/leaflet-assets.js
+++ b/addon/initializers/leaflet-assets.js
@@ -3,7 +3,7 @@ import config from 'ember-get-config';
 /* global L */
 
 export function initialize(/* container, application */) {
-  if (typeof FastBoot === 'undefined') {
+  if (typeof FastBoot === 'undefined' && typeof L !== 'undefined') {
     let prefix = '';
 
     if (!isNone(config.rootURL)) {


### PR DESCRIPTION
fix for https://github.com/miguelcobain/ember-leaflet/issues/366
When excludeJS: true and 'L'  not present do not run ember-leaflet initialier code