### PR TITLE
Merge pull request #422 from ttill/yield-addons

### DIFF
--- a/addon/components/leaflet-map.js
+++ b/addon/components/leaflet-map.js
@@ -16,6 +16,17 @@ export default BaseLayer.extend(ParentMixin, {
 
   emberLeaflet: service(),
 
+  actions: {
+    mergeComponents(obj) {
+      if (!this.mergedComponents) {
+        this.set("mergedComponents", obj);
+      } else {
+        Object.assign(this.mergedComponents, obj);
+      }
+    },
+  },
+
+
   leafletOptions: Object.freeze([
     // Map state options
     'center', 'zoom', 'minZoom', 'maxZoom', 'maxBounds', 'crs',

--- a/addon/components/leaflet-map.js
+++ b/addon/components/leaflet-map.js
@@ -19,7 +19,7 @@ export default BaseLayer.extend(ParentMixin, {
   actions: {
     mergeComponents(obj) {
       if (!this.mergedComponents) {
-        this.set("mergedComponents", obj);
+        this.set('mergedComponents', obj);
       } else {
         Object.assign(this.mergedComponents, obj);
       }

--- a/addon/templates/leaflet-map.hbs
+++ b/addon/templates/leaflet-map.hbs
@@ -23,7 +23,8 @@
         components
         key=c.as
         value=(component c.name parentComponent=this)
-        onChange=(action (mut mergedComponents))}}
+        onChange=(action "mergeComponents")
+      }}
     {{/each}}
 
     {{yield mergedComponents}}

--- a/tests/integration/components/leaflet-map-test.js
+++ b/tests/integration/components/leaflet-map-test.js
@@ -197,4 +197,34 @@ module('Integration | Component | leaflet map', function(hooks) {
     assert.ok(map._layer.getBounds() instanceof L.LatLngBounds);
     assert.boundsContain(map._layer.getBounds(), locations.bounds());
   });
+
+  test('addon components are yielded', async function(assert) {
+    this.emberLeaflet = this.owner.lookup('service:ember-leaflet');
+
+    [1, 2, 3].forEach(ix => {
+      this.owner.register(
+        `component:leaflet-component-${ix}`,
+        LeafletMapComponent.extend({})
+      );
+
+      this.emberLeaflet.registerComponent(`leaflet-component-${ix}`, {
+        as: `component-${ix}`
+      });
+    });
+
+    await render(hbs`
+      <LeafletMap @zoom={{zoom}} @center={{center}} as |layers|>
+        {{#each-in layers as |k v|}}
+          <yielded-layer>{{k}}</yielded-layer>
+        {{/each-in}}
+      </LeafletMap>
+    `);
+
+    assert.equal(
+      [...this.element.querySelectorAll('yielded-layer')].filter(
+        l => l.textContent.startsWith('component-')
+      ).length,
+      3
+    );
+  });
 });


### PR DESCRIPTION
We were not considering result of previous loop iteration in construction of object of components to yield. This meant only a single component would be yielded in addition to the components provided by ember-leaflet directly, no matter how many components were actually registered to the ember-leaflet service.