### PR TITLE
fix: Update the helper import path for documentation

### DIFF
--- a/addon/helpers/div-icon.js
+++ b/addon/helpers/div-icon.js
@@ -2,6 +2,14 @@ import { helper } from '@ember/component/helper';
 const isFastBoot = typeof FastBoot !== 'undefined';
 /* global L */
 
+export const divIcon = isFastBoot
+  ? function () {}
+  : function divIcon(_, hash) {
+      // https://github.com/emberjs/ember.js/issues/14668
+      let options = Object.assign({}, hash);
+      return L.divIcon(options);
+    };
+
 /**
  * Represents a lightweight icon for markers that uses a simple `<div>` element instead of an image.
  * Inherits from Icon but ignores the iconUrl and shadow options.
@@ -11,12 +19,4 @@ const isFastBoot = typeof FastBoot !== 'undefined';
  * @param {Object} options the DivIcon options object
  * @return {DivIcon}
  */
-export const divIcon = isFastBoot
-  ? function () {}
-  : function divIcon(_, hash) {
-      // https://github.com/emberjs/ember.js/issues/14668
-      let options = Object.assign({}, hash);
-      return L.divIcon(options);
-    };
-
 export default helper(divIcon);


### PR DESCRIPTION
- As per [comment here](https://github.com/miguelcobain/ember-leaflet/issues/689#issuecomment-2049749372):

> I think the confusion here was the import { divIcon } from 'ember-leaflet/helpers/div-icon'; import mentioned in the docs.
> That import imports the function, not the helper.
> 
> To import the helper, it should be import divIcon from 'ember-leaflet/helpers/div-icon';

I *think* moving the doc comment _should_(?) then pull the correct documentation into the docs?