### PR TITLE
Update ember-composability-tools to latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "broccoli-merge-trees": "^4.2.0",
         "ember-cli-babel": "^7.26.11",
         "ember-cli-htmlbars": "^6.2.0",
-        "ember-composability-tools": "^1.2.0",
+        "ember-composability-tools": "^2.0.0",
         "ember-in-element-polyfill": "^1.0.0",
         "ember-render-helpers": "^0.2.0",
         "fastboot-transform": "^0.1.3",
@@ -17732,9 +17732,9 @@
       }
     },
     "node_modules/ember-composability-tools": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/ember-composability-tools/-/ember-composability-tools-1.2.0.tgz",
-      "integrity": "sha512-OJpBMG1tYkWwgh+yfa+QEv88U6vHhVSBmcWBwFhvwW7YabcWUMpqEWO+mpRjj2n/tmmnsjl6RCqzrHp+/Kiu/A==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ember-composability-tools/-/ember-composability-tools-2.0.0.tgz",
+      "integrity": "sha512-V/jb78yzsFG0TElijTG/ds2kgbVfzzgRIzmXWH7x156bwCFNsT2k5JJP1g3d/clVrSpFb6D8nFqh9Jq/G14PHA==",
       "dependencies": {
         "@babel/core": "^7.22.10",
         "@ember/render-modifiers": "^1.0.2 || ^2.0.0",
@@ -50438,9 +50438,9 @@
       }
     },
     "ember-composability-tools": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/ember-composability-tools/-/ember-composability-tools-1.2.0.tgz",
-      "integrity": "sha512-OJpBMG1tYkWwgh+yfa+QEv88U6vHhVSBmcWBwFhvwW7YabcWUMpqEWO+mpRjj2n/tmmnsjl6RCqzrHp+/Kiu/A==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ember-composability-tools/-/ember-composability-tools-2.0.0.tgz",
+      "integrity": "sha512-V/jb78yzsFG0TElijTG/ds2kgbVfzzgRIzmXWH7x156bwCFNsT2k5JJP1g3d/clVrSpFb6D8nFqh9Jq/G14PHA==",
       "requires": {
         "@babel/core": "^7.22.10",
         "@ember/render-modifiers": "^1.0.2 || ^2.0.0",

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "broccoli-merge-trees": "^4.2.0",
     "ember-cli-babel": "^7.26.11",
     "ember-cli-htmlbars": "^6.2.0",
-    "ember-composability-tools": "^1.2.0",
+    "ember-composability-tools": "^2.0.0",
     "ember-in-element-polyfill": "^1.0.0",
     "ember-render-helpers": "^0.2.0",
     "fastboot-transform": "^0.1.3",


### PR DESCRIPTION
Following the release of version 2.0.0 that fixes [a cyber-security license risk](https://github.com/miguelcobain/ember-composability-tools/issues/61) I would like to request the update of ember-composability-tools. I tested the update using `ember test --server`.