### PR TITLE
remove ensure-safe-component

### DIFF
--- a/addon/components/base-layer.hbs
+++ b/addon/components/base-layer.hbs
@@ -16,7 +16,7 @@
       {{ember-leaflet-assign-to
         components
         key=(ember-leaflet-or c.as c.name)
-        value=(component (ensure-safe-component (ember-leaflet-or c.component c.name)) parent=this node=Node)
+        value=(component c.component parent=this node=Node)
         onChange=this.mergeComponents
       }}
     {{/each}}

--- a/addon/components/geojson-layer.hbs
+++ b/addon/components/geojson-layer.hbs
@@ -10,7 +10,7 @@
       {{ember-leaflet-assign-to
         components
         key=(ember-leaflet-or c.as c.name)
-        value=(component (ensure-safe-component (ember-leaflet-or c.component c.name)) parent=this node=Node)
+        value=(component c.component parent=this node=Node)
         onChange=this.mergeComponents
       }}
     {{/each}}

--- a/addon/components/leaflet-map.hbs
+++ b/addon/components/leaflet-map.hbs
@@ -12,7 +12,7 @@
       {{ember-leaflet-assign-to
         components
         key=(ember-leaflet-or c.as c.name)
-        value=(component (ensure-safe-component (ember-leaflet-or c.component c.name)) parent=this node=Node)
+        value=(component c.component parent=this node=Node)
         onChange=this.mergeComponents
       }}
     {{/each}}

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -23,28 +23,11 @@ module.exports = function (defaults) {
 
   const { maybeEmbroider } = require('@embroider/test-setup');
 
-  // These rules tell embroider that `c.component` (a block param property from
-  // #each this.componentsToYield) is safe to use with the (component) helper.
-  // The value is always a component class imported in the corresponding JS file,
-  // never a string, so this is safe under staticComponents: true.
-  const componentTemplates = [
-    'components/base-layer.hbs',
-    'components/leaflet-map.hbs',
-    'components/geojson-layer.hbs'
-  ];
-  const packageRules = [
-    {
-      package: 'ember-leaflet',
-      addonTemplates: Object.fromEntries(componentTemplates.map((t) => [t, { invokes: { 'c.component': [] } }]))
-    }
-  ];
-
   return maybeEmbroider(app, {
     skipBabel: [
       {
         package: 'qunit'
       }
-    ],
-    packageRules
+    ]
   });
 };

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -22,11 +22,29 @@ module.exports = function (defaults) {
   */
 
   const { maybeEmbroider } = require('@embroider/test-setup');
+
+  // These rules tell embroider that `c.component` (a block param property from
+  // #each this.componentsToYield) is safe to use with the (component) helper.
+  // The value is always a component class imported in the corresponding JS file,
+  // never a string, so this is safe under staticComponents: true.
+  const componentTemplates = [
+    'components/base-layer.hbs',
+    'components/leaflet-map.hbs',
+    'components/geojson-layer.hbs'
+  ];
+  const packageRules = [
+    {
+      package: 'ember-leaflet',
+      addonTemplates: Object.fromEntries(componentTemplates.map((t) => [t, { invokes: { 'c.component': [] } }]))
+    }
+  ];
+
   return maybeEmbroider(app, {
     skipBabel: [
       {
         package: 'qunit'
       }
-    ]
+    ],
+    packageRules
   });
 };


### PR DESCRIPTION
Closes #703.

## Summary

Removes usage of `ensure-safe-component` from the three templates that used it (`base-layer.hbs`, `leaflet-map.hbs`, `geojson-layer.hbs`).

**What changed:**
- `(component (ensure-safe-component (ember-leaflet-or c.component c.name)) parent=this node=Node)` → `(component c.component parent=this node=Node)`
- The `ember-leaflet-or` string-name fallback is dropped. Component registrations via `this.emberLeaflet.registerComponent()` must now always include a `component` class in options (e.g. `{ component: MyLayer }`). Passing only a string name is no longer supported — this matches the Ember 3.25+ recommendation of passing component classes rather than strings.
- `packageRules` added to `ember-cli-build.js` to declare `c.component` as a safe interior path for embroider's static analysis under `staticComponents: true`. Apps using embroider-optimized need to add equivalent `packageRules` to their own build config pointing at the three templates.

## How it works

Embroider's resolver-transform treats `(component dynamicExpr)` as an unsafe dynamic component unless `dynamicExpr` is either a statically-known identifier or explicitly declared safe. The `ensure-safe-component` name was a hardcoded bypass. The replacement uses embroider's `packageRules.addonTemplates[file].invokes` API, which adds declared paths to `safeInteriorPaths`, telling the resolver that `c.component` is intentionally dynamic and safe.

## Test plan

- [x] `pnpm lint` passes
- [x] `pnpm test:ember` passes (default build)
- [x] `ember try:one embroider-optimized` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)