### PR TITLE
Remove @ember/string dependency

### DIFF
--- a/addon/components/base-layer.js
+++ b/addon/components/base-layer.js
@@ -3,7 +3,7 @@ import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import Component from '@glimmer/component';
 import { scheduleOnce } from '@ember/runloop';
-import { classify } from '@ember/string';
+import { classify } from 'ember-leaflet/utils/classify';
 /* global L */
 
 const leaf = typeof L === 'undefined' ? {} : L;

--- a/addon/utils/classify.js
+++ b/addon/utils/classify.js
@@ -1,0 +1,6 @@
+export function classify(str) {
+  return str
+    .replace(/^[-_.]/, '')
+    .replace(/[-_.\s]+(.)?/g, (_, chr) => (chr ? chr.toUpperCase() : ''))
+    .replace(/^[a-z\d]*/i, (match) => match.charAt(0).toUpperCase() + match.slice(1));
+}

--- a/package.json
+++ b/package.json
@@ -46,8 +46,6 @@
     "ember-cli-sass": "^10.0.1",
     "ember-cli-sri": "^2.1.1",
     "ember-cli-terser": "^4.0.2",
-    "ember-data": "~4.11.0",
-    "ember-fetch": "^8.1.1",
     "ember-leaflet-marker-cluster": "^1.1.1",
     "ember-load-initializers": "^2.1.2",
     "ember-page-title": "^8.2.3",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "@babel/eslint-parser": "^7.25.1",
     "@babel/plugin-proposal-decorators": "^7.24.7",
     "@ember/optional-features": "^2.1.0",
-    "@ember/string": "^3.0.1",
     "@ember/test-helpers": "^3.3.1",
     "@embroider/test-setup": "^4.0.0",
     "broccoli-asset-rev": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@babel/eslint-parser": "^7.25.1",
     "@babel/plugin-proposal-decorators": "^7.24.7",
     "@ember/optional-features": "^2.1.0",
+    "@ember/string": "^3.1.1",
     "@ember/test-helpers": "^3.3.1",
     "@embroider/test-setup": "^4.0.0",
     "broccoli-asset-rev": "^3.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,9 +63,6 @@ importers:
       '@ember/optional-features':
         specifier: ^2.1.0
         version: 2.3.0
-      '@ember/string':
-        specifier: ^3.0.1
-        version: 3.1.1
       '@ember/test-helpers':
         specifier: ^3.3.1
         version: 3.3.1(@babel/core@7.29.7)(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.29.7))(rsvp@4.8.5)(webpack@5.108.0(postcss@8.5.15)))(webpack@5.108.0(postcss@8.5.15))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -117,12 +117,6 @@ importers:
       ember-cli-terser:
         specifier: ^4.0.2
         version: 4.0.2
-      ember-data:
-        specifier: ~4.11.0
-        version: 4.11.3(@babel/core@7.29.7)(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.29.7))(rsvp@4.8.5)(webpack@5.108.0(postcss@8.5.15)))(webpack@5.108.0(postcss@8.5.15))
-      ember-fetch:
-        specifier: ^8.1.1
-        version: 8.1.2
       ember-leaflet-marker-cluster:
         specifier: ^1.1.1
         version: 1.1.1(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.29.7))(rsvp@4.8.5)(webpack@5.108.0(postcss@8.5.15)))(leaflet@1.9.4)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,6 +63,9 @@ importers:
       '@ember/optional-features':
         specifier: ^2.1.0
         version: 2.3.0
+      '@ember/string':
+        specifier: ^3.1.1
+        version: 3.1.1
       '@ember/test-helpers':
         specifier: ^3.3.1
         version: 3.3.1(@babel/core@7.29.7)(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.29.7))(rsvp@4.8.5)(webpack@5.108.0(postcss@8.5.15)))(webpack@5.108.0(postcss@8.5.15))

--- a/tests/dummy/app/helpers/classify.js
+++ b/tests/dummy/app/helpers/classify.js
@@ -1,5 +1,5 @@
 import Helper from '@ember/component/helper';
-import { classify } from '@ember/string';
+import { classify } from 'ember-leaflet/utils/classify';
 
 export default Helper.helper(function ([arg1 = '']) {
   return classify(arg1);

--- a/tests/dummy/config/ember-try.js
+++ b/tests/dummy/config/ember-try.js
@@ -13,7 +13,6 @@ module.exports = async function () {
           devDependencies: {
             'ember-cli': '~4.12.0',
             'ember-source': '~3.28',
-            'ember-data': '~3.28',
             'ember-leaflet-marker-cluster': '0.2.0',
             'ember-resolver': '^8.1.0',
             leaflet: '~0.7.7'


### PR DESCRIPTION
## Summary

- Adds a small `classify()` utility at `addon/utils/classify.js` that converts strings to PascalCase, matching the behaviour of `@ember/string`'s `classify`
- Replaces the `@ember/string` import in `addon/components/base-layer.js` and `tests/dummy/app/helpers/classify.js` with the local utility — consumers no longer need `@ember/string` as a peer
- Removes `ember-data` and `ember-fetch` from `devDependencies`; neither is used by the addon or its tests (both were carried over from the Ember CLI blueprint)
- Keeps `@ember/string` as a `devDependency` because `ember-cli-addon-docs` (used to build the documentation site) still requires it in its current version

## Test plan

- [ ] Run `pnpm test` to verify all existing tests continue to pass
- [ ] Confirm `classify` produces correct output for event names (e.g. `"click"` → `"Click"`, `"mouseover"` → `"Mouseover"`) and property names (e.g. `"latLng"` → `"LatLng"`, `"lat"` → `"Lat"`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)